### PR TITLE
Lending term onboarding

### DIFF
--- a/protocol-configuration/roles.mainnet.json
+++ b/protocol-configuration/roles.mainnet.json
@@ -48,6 +48,7 @@
   ],
   "PROPOSER": [
     "GOVERNOR",
+    "LENDING_TERM_ONBOARDING",
     "TEAM_MULTISIG"
   ],
   "EXECUTOR": [

--- a/src/core/CoreRef.sol
+++ b/src/core/CoreRef.sol
@@ -39,6 +39,16 @@ abstract contract CoreRef is Pausable {
     function setCore(
         address newCore
     ) external onlyCoreRole(CoreRoles.GOVERNOR) {
+        _setCore(newCore);
+    }
+
+        /// @notice WARNING CALLING THIS FUNCTION CAN POTENTIALLY
+    /// BRICK A CONTRACT IF CORE IS SET INCORRECTLY
+    /// @notice set new reference to core
+    /// @param newCore to reference
+    function _setCore(
+        address newCore
+    ) internal {
         address oldCore = address(_core);
         _core = Core(newCore);
 

--- a/src/governance/LendingTermOffboarding.sol
+++ b/src/governance/LendingTermOffboarding.sol
@@ -7,11 +7,11 @@ import {GuildToken} from "@src/tokens/GuildToken.sol";
 import {LendingTerm} from "@src/loan/LendingTerm.sol";
 
 /// @notice Utils to offboard a LendingTerm.
-/// This contracts works somewhat similarly to a Veto governor: any GUILD holder can poll for the removal
+/// This contract works somewhat similarly to a Veto governor: any GUILD holder can poll for the removal
 /// of a lending term, and if enough GUILD holders vote for a removal poll, the term can be offboarded
 /// without delay.
 /// When a term is offboarded, no new loans can be issued, and GUILD holders cannot vote for the term anymore.
-/// After a term is offboarded, all the loans have to be called, and the term can be cleaned up (roles).
+/// After a term is offboarded, all the loans have to be called, then the term can be cleaned up (roles).
 contract LendingTermOffboarding is CoreRef {
     /// @notice emitted when a user supports the removal of a lending term
     event OffboardSupport(
@@ -152,7 +152,6 @@ contract LendingTermOffboarding is CoreRef {
         );
 
         // update protocol config
-        LendingTerm(term).setHardCap(0);
         core().revokeRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, term);
         core().revokeRole(CoreRoles.GAUGE_PNL_NOTIFIER, term);
 

--- a/src/governance/LendingTermOffboarding.sol
+++ b/src/governance/LendingTermOffboarding.sol
@@ -150,6 +150,10 @@ contract LendingTermOffboarding is CoreRef {
             LendingTerm(term).issuance() == 0,
             "LendingTermOffboarding: not all loans closed"
         );
+        require(
+            GuildToken(guildToken).isDeprecatedGauge(term),
+            "LendingTermOffboarding: re-onboarded"
+        );
 
         // update protocol config
         core().revokeRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, term);

--- a/src/governance/LendingTermOnboarding.sol
+++ b/src/governance/LendingTermOnboarding.sol
@@ -94,6 +94,7 @@ contract LendingTermOnboarding is VoltGovernor {
         );
 
         require(
+            // 31557601 comes from the constant LendingTerm.YEAR() + 1
             params.maxDelayBetweenPartialRepay < 31557601, // periodic payment every [0, 1 year]
             "LendingTermOnboarding: invalid maxDelayBetweenPartialRepay"
         );

--- a/src/governance/LendingTermOnboarding.sol
+++ b/src/governance/LendingTermOnboarding.sol
@@ -37,9 +37,18 @@ contract LendingTermOnboarding is VoltGovernor {
     /// (used to check that a term has been created by this factory)
     mapping(address=>uint256) public created;
 
+    /// @notice reference to profitManager to set in created lending terms
+    address public immutable profitManager;
+    /// @notice reference to auctionHouse to set in created lending terms
+    address public immutable auctionHouse;
+    /// @notice reference to creditMinter to set in created lending terms
+    address public immutable creditMinter;
+    /// @notice reference to creditToken to set in created lending terms
+    address public immutable creditToken;
+
     constructor(
         address _lendingTermImplementation,
-        address _guildToken,
+        LendingTerm.LendingTermReferences memory _lendingTermReferences,
         uint256 _gaugeType,
         address _core,
         address _timelock,
@@ -51,7 +60,7 @@ contract LendingTermOnboarding is VoltGovernor {
         VoltGovernor(
             _core,
             _timelock,
-            _guildToken,
+            _lendingTermReferences.guildToken,
             initialVotingDelay,
             initialVotingPeriod,
             initialProposalThreshold,
@@ -59,16 +68,26 @@ contract LendingTermOnboarding is VoltGovernor {
         )
     {
         lendingTermImplementation = _lendingTermImplementation;
-        guildToken = _guildToken;
+        guildToken = _lendingTermReferences.guildToken;
         gaugeType = _gaugeType;
+        profitManager = _lendingTermReferences.profitManager;
+        auctionHouse = _lendingTermReferences.auctionHouse;
+        creditMinter = _lendingTermReferences.creditMinter;
+        creditToken = _lendingTermReferences.creditToken;
     }
 
     /// @notice Create a new LendingTerm and initialize it.
     function createTerm(LendingTerm.LendingTermParams calldata params) external returns (address) {
         address term = Clones.clone(lendingTermImplementation);
         LendingTerm(term).initialize(
-            address(LendingTerm(lendingTermImplementation).core()),
-            LendingTerm(lendingTermImplementation).getReferences(),
+            address(core()),
+            LendingTerm.LendingTermReferences({
+                profitManager: profitManager,
+                guildToken: guildToken,
+                auctionHouse: auctionHouse,
+                creditMinter: creditMinter,
+                creditToken: creditToken
+            }),
             params
         );
         created[term] = block.timestamp;

--- a/src/governance/LendingTermOnboarding.sol
+++ b/src/governance/LendingTermOnboarding.sol
@@ -86,7 +86,7 @@ contract LendingTermOnboarding is VoltGovernor {
     }
 
     /// @notice Propose the onboarding of a term
-    function proposeOnboard(address term) external returns (uint256 proposalId) {
+    function proposeOnboard(address term) external whenNotPaused returns (uint256 proposalId) {
         // Check that the term has been created by this factory
         require(created[term] != 0, "LendingTermOnboarding: invalid term");
 

--- a/src/governance/LendingTermOnboarding.sol
+++ b/src/governance/LendingTermOnboarding.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
+
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Governor, IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";
+
+import {Core} from "@src/core/Core.sol";
+import {CoreRoles} from "@src/core/CoreRoles.sol";
+import {GuildToken} from "@src/tokens/GuildToken.sol";
+import {LendingTerm} from "@src/loan/LendingTerm.sol";
+import {VoltGovernor} from "@src/governance/VoltGovernor.sol";
+
+/// @notice Utils to onboard a LendingTerm. Also acts as a LendingTerm factory.
+/// This contract acts as Governor, but users cannot queue arbitrary proposals,
+/// they can only queue LendingTerm onboarding proposals.
+/// When a vote is successful, the LendingTerm onboarding is queued in the Timelock,
+/// where CREDIT holders can veto the onboarding.
+/// Only terms that have been deployed through this factory can be onboarded.
+/// A term can be onboarded for the first time, or re-onboarded after it has been offboarded.
+contract LendingTermOnboarding is VoltGovernor {
+
+    uint256 MIN_DELAY_BETWEEN_PROPOSALS = 7 days;
+    address public immutable lendingTermImplementation;
+    address public immutable guildToken;
+    uint256 public immutable gaugeType;
+    mapping(address=>uint256) public created;
+    mapping(address=>uint256) public lastProposal;
+    
+    constructor(
+        address _lendingTermImplementation,
+        address _guildToken,
+        uint256 _gaugeType,
+        address _core,
+        address _timelock,
+        address _token,
+        uint256 initialVotingDelay,
+        uint256 initialVotingPeriod,
+        uint256 initialProposalThreshold,
+        uint256 initialQuorum
+    )
+        VoltGovernor(
+            _core,
+            _timelock,
+            _token,
+            initialVotingDelay,
+            initialVotingPeriod,
+            initialProposalThreshold,
+            initialQuorum
+        )
+    {
+        lendingTermImplementation = _lendingTermImplementation;
+        guildToken = _guildToken;
+        gaugeType = _gaugeType;
+    }
+
+    /// @notice Create a new LendingTerm and initialize it.
+    function createTerm(LendingTerm.LendingTermParams calldata params) external returns (address) {
+        address term = Clones.clone(lendingTermImplementation);
+        LendingTerm(term).initialize(
+            address(LendingTerm(lendingTermImplementation).core()),
+            LendingTerm(lendingTermImplementation).getReferences(),
+            params
+        );
+        created[term] = block.timestamp;
+        return term;
+    }
+
+    /// @dev override to prevent arbitrary calls to be proposed
+    function propose(
+        address[] memory /* targets*/,
+        uint256[] memory /* values*/,
+        bytes[] memory /* calldatas*/,
+        string memory /* description*/
+    ) public pure override(IGovernor, Governor) returns (uint256) {
+        revert("LendingTermOnboarding: cannot propose arbitrary actions");
+    }
+
+    /// @notice Propose the onboarding of a term
+    function proposeOnboard(address term) external returns (uint256 proposalId) {
+        // Check that the term has been created by this factory
+        require(created[term] != 0, "LendingTermOnboarding: invalid term");
+
+        // Check that the term was not subject to an onboard vote recently
+        require(lastProposal[term] + MIN_DELAY_BETWEEN_PROPOSALS < block.timestamp, "LendingTermOnboarding: recently proposed");
+        lastProposal[term] = block.timestamp;
+        
+        // Check that the term is not already active
+        bool isGauge = GuildToken(guildToken).isGauge(term);
+        require(!isGauge, "LendingTermOnboarding: active term");
+
+        // Generate calldata for the proposal
+        (
+            address[] memory targets,
+            uint256[] memory values,
+            bytes[] memory calldatas,
+            string memory description
+        ) = getOnboardProposeArgs(term);
+
+        // propose
+        return Governor.propose(targets, values, calldatas, description);
+    }
+
+    /// @notice Generate the calldata for the onboarding of a term
+    function getOnboardProposeArgs(address term) public view returns (
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description
+    ) {
+        targets = new address[](3);
+        values = new uint256[](3);
+        calldatas = new bytes[](3);
+        description = string.concat("Enable term ", Strings.toHexString(uint160(term), 20));
+
+        // 1st call: guild.addGauge(term)
+        targets[0] = guildToken;
+        calldatas[0] = abi.encodeWithSelector(
+            GuildToken.addGauge.selector,
+            gaugeType,
+            term
+        );
+
+        // 2nd call: core.grantRole(term, RATE_LIMITED_CREDIT_MINTER)
+        address _core = address(core());
+        targets[1] = _core;
+        calldatas[1] = abi.encodeWithSelector(
+            AccessControl.grantRole.selector,
+            CoreRoles.RATE_LIMITED_CREDIT_MINTER,
+            term
+        );
+
+        // 3rd call: core.grantRole(term, GAUGE_PNL_NOTIFIER)
+        targets[2] = _core;
+        calldatas[2] = abi.encodeWithSelector(
+            AccessControl.grantRole.selector,
+            CoreRoles.GAUGE_PNL_NOTIFIER,
+            term
+        );
+    }
+}

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -162,7 +162,11 @@ contract LendingTerm is CoreRef {
     /// @notice Params of the LendingTerm (see struct for more details)
     LendingTermParams internal params;
 
-    constructor() CoreRef(address(0)) {}
+    constructor() CoreRef(address(1)) {
+        // prevent implementation to be initialized,
+        // only proxies on the implementation can be initialized.
+        _setCore(address(1));
+    }
 
     /// @notice initialize storage with references to other protocol contracts
     /// and the lending term parameters for this instance.

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -163,9 +163,8 @@ contract LendingTerm is CoreRef {
     LendingTermParams internal params;
 
     constructor() CoreRef(address(1)) {
-        // prevent implementation to be initialized,
+        // core is set to address(1) to prevent implementation from being initialized,
         // only proxies on the implementation can be initialized.
-        _setCore(address(1));
     }
 
     /// @notice initialize storage with references to other protocol contracts

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -74,64 +74,10 @@ contract LendingTerm is CoreRef {
     /// would set a debt ceiling to 100 CREDIT, the issuance could go as high as 120 CREDIT.
     uint256 public constant GAUGE_CAP_TOLERANCE = 1.2e18;
 
-    /// @notice reference to the ProfitManager
-    address public immutable profitManager;
-
-    /// @notice reference to the GUILD token
-    address public immutable guildToken;
-
-    /// @notice reference to the auction house contract used to
-    /// sell loan collateral for CREDIT if loans are called.
-    address public auctionHouse;
-
-    /// @notice reference to the credit minter contract
-    address public immutable creditMinter;
-
-    /// @notice reference to the CREDIT token
-    address public immutable creditToken;
-
-    /// @notice reference to the collateral token
-    address public immutable collateralToken;
-
-    /// @notice max number of debt tokens issued per collateral token.
-    /// @dev be mindful of the decimals here, because if collateral
-    /// token doesn't have 18 decimals, this variable is used to scale
-    /// the decimals.
-    /// For example, for USDC collateral, this variable should be around
-    /// ~1e30, to allow 1e6 * 1e30 / 1e18 ~= 1e18 CREDIT to be borrowed for
-    /// each 1e6 units (1 USDC) of collateral, if CREDIT is targeted to be
-    /// worth around 1 USDC.
-    uint256 public immutable maxDebtPerCollateralToken;
-
-    /// @notice interest rate paid by the borrower, expressed as an APR
-    /// with 18 decimals (0.01e18 = 1% APR). The base for 1 year is the YEAR constant.
-    uint256 public immutable interestRate;
-
-    /// @notice maximum delay, in seconds, between partial debt repayments.
-    /// if set to 0, no periodic partial repayments are expected.
-    /// if a partial repayment is missed (delay has passed), the loan
-    /// can be called.
-    uint256 public immutable maxDelayBetweenPartialRepay;
-
-    /// @notice minimum percent of the total debt (principal + interests) to
-    /// repay during partial debt repayments.
-    /// percentage is expressed with 18 decimals, e.g. 0.05e18 = 5% debt.
-    uint256 public immutable minPartialRepayPercent;
-
     /// @notice timestamp of last partial repayment for a given loanId.
     /// during borrow(), this is initialized to the borrow timestamp, if
     /// maxDelayBetweenPartialRepay is != 0
     mapping(bytes32 => uint256) public lastPartialRepay;
-
-    /// @notice the opening fee is a small amount of CREDIT provided by the borrower
-    /// when the loan is opened.
-    /// The opening fee is expressed as a percentage of the borrowAmount, with 18
-    /// decimals, e.g. 0.05e18 = 5% of the borrowed amount.
-    uint256 public immutable openingFee;
-
-    /// @notice the absolute maximum amount of debt this lending term can issue
-    /// at any given time, regardless of the gauge allocations.
-    uint256 public hardCap;
 
     struct Loan {
         address borrower; // address of a loan's borrower
@@ -152,37 +98,102 @@ contract LendingTerm is CoreRef {
     /// @notice current number of CREDIT issued in active loans on this term
     uint256 public issuance;
 
+    struct LendingTermReferences {
+        /// @notice reference to the ProfitManager
+        address profitManager;
+
+        /// @notice reference to the GUILD token
+        address guildToken;
+
+        /// @notice reference to the auction house contract used to
+        /// sell loan collateral for CREDIT if loans are called.
+        address auctionHouse;
+
+        /// @notice reference to the credit minter contract
+        address creditMinter;
+
+        /// @notice reference to the CREDIT token
+        address creditToken;
+    }
+
+    /// @notice References to other protocol contracts (see struct for more details)
+    LendingTermReferences internal refs;
+
     struct LendingTermParams {
+        /// @notice reference to the collateral token
         address collateralToken;
+
+        /// @notice max number of debt tokens issued per collateral token.
+        /// @dev be mindful of the decimals here, because if collateral
+        /// token doesn't have 18 decimals, this variable is used to scale
+        /// the decimals.
+        /// For example, for USDC collateral, this variable should be around
+        /// ~1e30, to allow 1e6 * 1e30 / 1e18 ~= 1e18 CREDIT to be borrowed for
+        /// each 1e6 units (1 USDC) of collateral, if CREDIT is targeted to be
+        /// worth around 1 USDC.
         uint256 maxDebtPerCollateralToken;
+
+        /// @notice interest rate paid by the borrower, expressed as an APR
+        /// with 18 decimals (0.01e18 = 1% APR). The base for 1 year is the YEAR constant.
         uint256 interestRate;
+
+        /// @notice maximum delay, in seconds, between partial debt repayments.
+        /// if set to 0, no periodic partial repayments are expected.
+        /// if a partial repayment is missed (delay has passed), the loan
+        /// can be called.
         uint256 maxDelayBetweenPartialRepay;
+
+        /// @notice minimum percent of the total debt (principal + interests) to
+        /// repay during partial debt repayments.
+        /// percentage is expressed with 18 decimals, e.g. 0.05e18 = 5% debt.
         uint256 minPartialRepayPercent;
+
+        /// @notice the opening fee is a small amount of CREDIT provided by the borrower
+        /// when the loan is opened.
+        /// The opening fee is expressed as a percentage of the borrowAmount, with 18
+        /// decimals, e.g. 0.05e18 = 5% of the borrowed amount.
         uint256 openingFee;
+
+        /// @notice the absolute maximum amount of debt this lending term can issue
+        /// at any given time, regardless of the gauge allocations.
         uint256 hardCap;
     }
 
-    constructor(
+    /// @notice Params of the LendingTerm (see struct for more details)
+    LendingTermParams internal params;
+
+    constructor() CoreRef(address(0)) {}
+
+    /// @notice initialize storage with references to other protocol contracts
+    /// and the lending term parameters for this instance.
+    function initialize(
         address _core,
-        address _profitManager,
-        address _guildToken,
-        address _auctionHouse,
-        address _creditMinter,
-        address _creditToken,
-        LendingTermParams memory params
-    ) CoreRef(_core) {
-        profitManager = _profitManager;
-        guildToken = _guildToken;
-        auctionHouse = _auctionHouse;
-        creditMinter = _creditMinter;
-        creditToken = _creditToken;
-        collateralToken = params.collateralToken;
-        maxDebtPerCollateralToken = params.maxDebtPerCollateralToken;
-        interestRate = params.interestRate;
-        maxDelayBetweenPartialRepay = params.maxDelayBetweenPartialRepay;
-        minPartialRepayPercent = params.minPartialRepayPercent;
-        openingFee = params.openingFee;
-        hardCap = params.hardCap;
+        LendingTermReferences calldata _refs,
+        LendingTermParams calldata _params
+    ) external {
+        // can initialize only once
+        assert(address(core()) == address(0));
+        assert(_core != address(0));
+
+        // initialize storage
+        _setCore(_core);
+        refs = _refs;
+        params = _params;
+    }
+
+    /// @notice get references of this term to other protocol contracts
+    function getReferences() external view returns (LendingTermReferences memory) {
+        return refs;
+    }
+
+    /// @notice get parameters of this term
+    function getParameters() external view returns (LendingTermParams memory) {
+        return params;
+    }
+
+    /// @notice get parameter 'collateralToken' of this term
+    function collateralToken() external view returns (address) {
+        return params.collateralToken;
     }
 
     /// @notice get a loan
@@ -210,12 +221,12 @@ contract LendingTerm is CoreRef {
         // compute interest owed
         uint256 borrowAmount = loan.borrowAmount;
         uint256 interest = (borrowAmount *
-            interestRate *
+            params.interestRate *
             (block.timestamp - borrowTime)) /
             YEAR /
             1e18;
         uint256 loanDebt = borrowAmount + interest;
-        uint256 creditMultiplier = ProfitManager(profitManager).creditMultiplier();
+        uint256 creditMultiplier = ProfitManager(refs.profitManager).creditMultiplier();
         loanDebt = loanDebt * loan.borrowCreditMultiplier / creditMultiplier;
 
         return loanDebt;
@@ -227,7 +238,7 @@ contract LendingTerm is CoreRef {
         bytes32 loanId
     ) public view returns (bool) {
         // if no periodic partial repays are expected, always return false
-        if (maxDelayBetweenPartialRepay == 0) return false;
+        if (params.maxDelayBetweenPartialRepay == 0) return false;
 
         // if loan doesn't exist, return false
         if (loans[loanId].borrowTime == 0) return false;
@@ -238,7 +249,7 @@ contract LendingTerm is CoreRef {
         // return true if delay is passed
         return
             lastPartialRepay[loanId] <
-            block.timestamp - maxDelayBetweenPartialRepay;
+            block.timestamp - params.maxDelayBetweenPartialRepay;
     }
 
     /// @notice initiate a new loan
@@ -264,9 +275,9 @@ contract LendingTerm is CoreRef {
         );
 
         // check that enough collateral is provided
-        uint256 maxBorrow = (collateralAmount * maxDebtPerCollateralToken) /
+        uint256 maxBorrow = (collateralAmount * params.maxDebtPerCollateralToken) /
             1e18;
-        uint256 creditMultiplier = ProfitManager(profitManager).creditMultiplier();
+        uint256 creditMultiplier = ProfitManager(refs.profitManager).creditMultiplier();
         maxBorrow = maxBorrow * 1e18 / creditMultiplier;
         require(
             borrowAmount <= maxBorrow,
@@ -276,11 +287,11 @@ contract LendingTerm is CoreRef {
         // check the hardcap
         uint256 _issuance = issuance;
         uint256 _postBorrowIssuance = _issuance + borrowAmount;
-        require(_postBorrowIssuance <= hardCap, "LendingTerm: hardcap reached");
+        require(_postBorrowIssuance <= params.hardCap, "LendingTerm: hardcap reached");
 
         // check the debt ceiling
-        uint256 _totalSupply = CreditToken(creditToken).totalSupply();
-        uint256 debtCeiling = (GuildToken(guildToken).calculateGaugeAllocation(
+        uint256 _totalSupply = CreditToken(refs.creditToken).totalSupply();
+        uint256 debtCeiling = (GuildToken(refs.guildToken).calculateGaugeAllocation(
             address(this),
             _totalSupply + borrowAmount
         ) * GAUGE_CAP_TOLERANCE) / 1e18;
@@ -309,30 +320,30 @@ contract LendingTerm is CoreRef {
             closeTime: 0
         });
         issuance = _postBorrowIssuance;
-        if (maxDelayBetweenPartialRepay != 0) {
+        if (params.maxDelayBetweenPartialRepay != 0) {
             lastPartialRepay[loanId] = block.timestamp;
         }
 
         // mint debt to the borrower
-        RateLimitedMinter(creditMinter).mint(borrower, borrowAmount);
+        RateLimitedMinter(refs.creditMinter).mint(borrower, borrowAmount);
 
         // pull opening fee from the borrower, if any
-        if (openingFee != 0) {
-            uint256 _openingFee = (borrowAmount * openingFee) / 1e18;
+        if (params.openingFee != 0) {
+            uint256 _openingFee = (borrowAmount * params.openingFee) / 1e18;
             // transfer from borrower to ProfitManager & report profit
-            CreditToken(creditToken).transferFrom(
+            CreditToken(refs.creditToken).transferFrom(
                 borrower,
-                profitManager,
+                refs.profitManager,
                 _openingFee
             );
-            ProfitManager(profitManager).notifyPnL(
+            ProfitManager(refs.profitManager).notifyPnL(
                 address(this),
                 int256(_openingFee)
             );
         }
 
         // pull the collateral from the borrower
-        IERC20(collateralToken).safeTransferFrom(
+        IERC20(params.collateralToken).safeTransferFrom(
             borrower,
             address(this),
             collateralAmount
@@ -363,7 +374,7 @@ contract LendingTerm is CoreRef {
         uint256 deadline,
         Signature calldata sig
     ) external whenNotPaused returns (bytes32 loanId) {
-        IERC20Permit(collateralToken).permit(
+        IERC20Permit(params.collateralToken).permit(
             msg.sender,
             address(this),
             collateralAmount,
@@ -382,10 +393,10 @@ contract LendingTerm is CoreRef {
         uint256 deadline,
         Signature calldata sig
     ) external whenNotPaused returns (bytes32 loanId) {
-        IERC20Permit(creditToken).permit(
+        IERC20Permit(refs.creditToken).permit(
             msg.sender,
             address(this),
-            (borrowAmount * openingFee) / 1e18,
+            (borrowAmount * params.openingFee) / 1e18,
             deadline,
             sig.v,
             sig.r,
@@ -402,17 +413,17 @@ contract LendingTerm is CoreRef {
         Signature calldata collateralPermitSig,
         Signature calldata creditPermitSig
     ) external whenNotPaused returns (bytes32 loanId) {
-        IERC20Permit(creditToken).permit(
+        IERC20Permit(refs.creditToken).permit(
             msg.sender,
             address(this),
-            (borrowAmount * openingFee) / 1e18,
+            (borrowAmount * params.openingFee) / 1e18,
             deadline,
             creditPermitSig.v,
             creditPermitSig.r,
             creditPermitSig.s
         );
 
-        IERC20Permit(collateralToken).permit(
+        IERC20Permit(params.collateralToken).permit(
             msg.sender,
             address(this),
             collateralAmount,
@@ -446,7 +457,7 @@ contract LendingTerm is CoreRef {
         loans[loanId].collateralAmount += collateralToAdd;
 
         // pull the collateral from the borrower
-        IERC20(collateralToken).safeTransferFrom(
+        IERC20(params.collateralToken).safeTransferFrom(
             borrower,
             address(this),
             collateralToAdd
@@ -473,7 +484,7 @@ contract LendingTerm is CoreRef {
         uint256 deadline,
         Signature calldata sig
     ) external {
-        IERC20Permit(collateralToken).permit(
+        IERC20Permit(params.collateralToken).permit(
             msg.sender,
             address(this),
             collateralToAdd,
@@ -512,7 +523,7 @@ contract LendingTerm is CoreRef {
         require(debtToRepay < loanDebt, "LendingTerm: full repayment");
         uint256 percentRepaid = (debtToRepay * 1e18) / loanDebt; // [0, 1e18[
         uint256 borrowAmount = loan.borrowAmount;
-        uint256 creditMultiplier = ProfitManager(profitManager).creditMultiplier();
+        uint256 creditMultiplier = ProfitManager(refs.profitManager).creditMultiplier();
         uint256 principal = borrowAmount * loan.borrowCreditMultiplier / creditMultiplier;
         uint256 principalRepaid = (principal * percentRepaid) / 1e18;
         uint256 interestRepaid = debtToRepay - principalRepaid;
@@ -522,7 +533,7 @@ contract LendingTerm is CoreRef {
             "LendingTerm: repay too small"
         );
         require(
-            debtToRepay >= (loanDebt * minPartialRepayPercent) / 1e18,
+            debtToRepay >= (loanDebt * params.minPartialRepayPercent) / 1e18,
             "LendingTerm: repay below min"
         );
         require(
@@ -534,22 +545,22 @@ contract LendingTerm is CoreRef {
         loans[loanId].borrowAmount -= issuanceDecrease;
         lastPartialRepay[loanId] = block.timestamp;
         issuance -= issuanceDecrease;
-        RateLimitedMinter(creditMinter).replenishBuffer(issuanceDecrease);
+        RateLimitedMinter(refs.creditMinter).replenishBuffer(issuanceDecrease);
 
         // pull the debt from the borrower
-        CreditToken(creditToken).transferFrom(
+        CreditToken(refs.creditToken).transferFrom(
             repayer,
             address(this),
             debtToRepay
         );
 
         // forward profit portion to the ProfitManager, burn the rest
-        CreditToken(creditToken).transfer(profitManager, interestRepaid);
-        ProfitManager(profitManager).notifyPnL(
+        CreditToken(refs.creditToken).transfer(refs.profitManager, interestRepaid);
+        ProfitManager(refs.profitManager).notifyPnL(
             address(this),
             int256(interestRepaid)
         );
-        CreditToken(creditToken).burn(principalRepaid);
+        CreditToken(refs.creditToken).burn(principalRepaid);
 
         // emit event
         emit LoanPartialRepay(block.timestamp, loanId, repayer, debtToRepay);
@@ -567,7 +578,7 @@ contract LendingTerm is CoreRef {
         uint256 deadline,
         Signature calldata sig
     ) external {
-        IERC20Permit(creditToken).permit(
+        IERC20Permit(refs.creditToken).permit(
             msg.sender,
             address(this),
             debtToRepay,
@@ -597,23 +608,23 @@ contract LendingTerm is CoreRef {
         // compute interest owed
         uint256 loanDebt = getLoanDebt(loanId);
         uint256 borrowAmount = loan.borrowAmount;
-        uint256 creditMultiplier = ProfitManager(profitManager).creditMultiplier();
+        uint256 creditMultiplier = ProfitManager(refs.profitManager).creditMultiplier();
         uint256 principal = borrowAmount * loan.borrowCreditMultiplier / creditMultiplier;
         uint256 interest = loanDebt - principal;
 
         /// pull debt from the borrower and replenish the buffer of available debt that can be minted.
-        CreditToken(creditToken).transferFrom(
+        CreditToken(refs.creditToken).transferFrom(
             repayer,
             address(this),
             loanDebt
         );
         if (interest != 0) {
             // forward profit portion to the ProfitManager, burn the rest
-            CreditToken(creditToken).transfer(profitManager, interest);
-            CreditToken(creditToken).burn(principal);
+            CreditToken(refs.creditToken).transfer(refs.profitManager, interest);
+            CreditToken(refs.creditToken).burn(principal);
 
             // report profit
-            ProfitManager(profitManager).notifyPnL(
+            ProfitManager(refs.profitManager).notifyPnL(
                 address(this),
                 int256(interest)
             );
@@ -622,10 +633,10 @@ contract LendingTerm is CoreRef {
         // close the loan
         loan.closeTime = block.timestamp;
         issuance -= borrowAmount;
-        RateLimitedMinter(creditMinter).replenishBuffer(borrowAmount);
+        RateLimitedMinter(refs.creditMinter).replenishBuffer(borrowAmount);
 
         // return the collateral to the borrower
-        IERC20(collateralToken).safeTransfer(
+        IERC20(params.collateralToken).safeTransfer(
             loan.borrower,
             loan.collateralAmount
         );
@@ -646,7 +657,7 @@ contract LendingTerm is CoreRef {
         uint256 deadline,
         Signature calldata sig
     ) external {
-        IERC20Permit(creditToken).permit(
+        IERC20Permit(refs.creditToken).permit(
             msg.sender,
             address(this),
             maxDebt,
@@ -676,7 +687,7 @@ contract LendingTerm is CoreRef {
 
         // check that the loan can be called
         require(
-            GuildToken(guildToken).isDeprecatedGauge(address(this)) || partialRepayDelayPassed(loanId),
+            GuildToken(refs.guildToken).isDeprecatedGauge(address(this)) || partialRepayDelayPassed(loanId),
             "LendingTerm: cannot call"
         );
 
@@ -701,12 +712,12 @@ contract LendingTerm is CoreRef {
 
     /// @notice call a single loan
     function call(bytes32 loanId) external {
-        _call(msg.sender, loanId, auctionHouse);
+        _call(msg.sender, loanId, refs.auctionHouse);
     }
 
     /// @notice call a list of loans
     function callMany(bytes32[] memory loanIds) public {
-        address _auctionHouse = auctionHouse;
+        address _auctionHouse = refs.auctionHouse;
         for (uint256 i = 0; i < loanIds.length; i++) {
             _call(msg.sender, loanIds[i], _auctionHouse);
         }
@@ -732,10 +743,10 @@ contract LendingTerm is CoreRef {
 
         // mark loan as a total loss
         int256 pnl = -int256(loan.borrowAmount);
-        ProfitManager(profitManager).notifyPnL(address(this), pnl);
+        ProfitManager(refs.profitManager).notifyPnL(address(this), pnl);
 
         // set hardcap to 0 to prevent new borrows
-        hardCap = 0;
+        params.hardCap = 0;
 
         // emit event
         emit LoanClose(block.timestamp, loanId, LoanCloseType.Forgive, 0);
@@ -750,7 +761,7 @@ contract LendingTerm is CoreRef {
         uint256 creditFromBidder
     ) external {
         // preliminary checks
-        require(msg.sender == auctionHouse, "LendingTerm: invalid caller");
+        require(msg.sender == refs.auctionHouse, "LendingTerm: invalid caller");
         require(loans[loanId].callTime != 0 && loans[loanId].callDebt != 0, "LendingTerm: loan not called");
         require(loans[loanId].closeTime == 0, "LendingTerm: loan closed");
 
@@ -765,7 +776,7 @@ contract LendingTerm is CoreRef {
         );
 
         // compute pnl
-        uint256 creditMultiplier = ProfitManager(profitManager).creditMultiplier();
+        uint256 creditMultiplier = ProfitManager(refs.profitManager).creditMultiplier();
         uint256 borrowAmount = loans[loanId].borrowAmount;
         uint256 principal = borrowAmount * loans[loanId].borrowCreditMultiplier / creditMultiplier;
         int256 pnl;
@@ -784,7 +795,7 @@ contract LendingTerm is CoreRef {
 
         // pull credit from bidder
         if (creditFromBidder != 0) {
-            CreditToken(creditToken).transferFrom(
+            CreditToken(refs.creditToken).transferFrom(
                 bidder,
                 address(this),
                 creditFromBidder
@@ -793,28 +804,28 @@ contract LendingTerm is CoreRef {
 
         // burn credit principal
         if (principal != 0) {
-            CreditToken(creditToken).burn(principal);
+            CreditToken(refs.creditToken).burn(principal);
         }
 
         // handle profit & losses
         if (pnl != 0) {
             // forward profit, if any
             if (interest != 0) {
-                CreditToken(creditToken).transfer(
-                    profitManager,
+                CreditToken(refs.creditToken).transfer(
+                    refs.profitManager,
                     interest
                 );
             }
-            ProfitManager(profitManager).notifyPnL(address(this), pnl);
+            ProfitManager(refs.profitManager).notifyPnL(address(this), pnl);
         }
 
         // replenish buffer, decrease issuance
-        RateLimitedMinter(creditMinter).replenishBuffer(borrowAmount);
+        RateLimitedMinter(refs.creditMinter).replenishBuffer(borrowAmount);
         issuance -= borrowAmount;
 
         // send collateral to borrower
         if (collateralToBorrower != 0) {
-            IERC20(collateralToken).safeTransfer(
+            IERC20(params.collateralToken).safeTransfer(
                 loans[loanId].borrower,
                 collateralToBorrower
             );
@@ -822,7 +833,7 @@ contract LendingTerm is CoreRef {
 
         // send collateral to bidder
         if (collateralToBidder != 0) {
-            IERC20(collateralToken).safeTransfer(
+            IERC20(params.collateralToken).safeTransfer(
                 bidder,
                 collateralToBidder
             );
@@ -846,11 +857,11 @@ contract LendingTerm is CoreRef {
         // lifecycle, as it would prevent the former auctionHouse (that have active auctions)
         // from reporting the result to the lending term.
         require(
-            AuctionHouse(auctionHouse).nAuctionsInProgress() == 0,
+            AuctionHouse(refs.auctionHouse).nAuctionsInProgress() == 0,
             "LendingTerm: auctions in progress"
         );
 
-        auctionHouse = _newValue;
+        refs.auctionHouse = _newValue;
     }
 
     /// @notice set the hardcap of CREDIT mintable in this term.
@@ -858,6 +869,6 @@ contract LendingTerm is CoreRef {
     function setHardCap(
         uint256 _newValue
     ) external onlyCoreRole(CoreRoles.GOVERNOR) {
-        hardCap = _newValue;
+        params.hardCap = _newValue;
     }
 }

--- a/test/proposals/Proposal_0.sol
+++ b/test/proposals/Proposal_0.sol
@@ -88,25 +88,6 @@ contract Proposal_0 is Proposal {
             );
 
             LendingTerm termV1 = new LendingTerm();
-            termV1.initialize(
-                addresses.mainnet("CORE"),
-                LendingTerm.LendingTermReferences({
-                    profitManager: addresses.mainnet("PROFIT_MANAGER"),
-                    guildToken: addresses.mainnet("ERC20_GUILD"),
-                    auctionHouse: address(auctionHouse),
-                    creditMinter: addresses.mainnet("RATE_LIMITED_CREDIT_MINTER"),
-                    creditToken: addresses.mainnet("ERC20_CREDIT")
-                }),
-                LendingTerm.LendingTermParams({
-                    collateralToken: address(0),
-                    maxDebtPerCollateralToken: 0,
-                    interestRate: 0,
-                    maxDelayBetweenPartialRepay: 0,
-                    minPartialRepayPercent: 0,
-                    openingFee: 0,
-                    hardCap: 0
-                })
-            );
 
             addresses.addMainnet("AUCTION_HOUSE_1", address(auctionHouse));
             addresses.addMainnet("LENDING_TERM_V1", address(termV1));
@@ -140,7 +121,13 @@ contract Proposal_0 is Proposal {
             );
             LendingTermOnboarding termOnboarding = new LendingTermOnboarding(
                 addresses.mainnet("LENDING_TERM_V1"), // _lendingTermImplementation
-                addresses.mainnet("ERC20_GUILD"), // _guildToken
+                LendingTerm.LendingTermReferences({
+                    profitManager: addresses.mainnet("PROFIT_MANAGER"),
+                    guildToken: addresses.mainnet("ERC20_GUILD"),
+                    auctionHouse: addresses.mainnet("AUCTION_HOUSE_V1"),
+                    creditMinter: addresses.mainnet("RATE_LIMITED_CREDIT_MINTER"),
+                    creditToken: addresses.mainnet("ERC20_CREDIT")
+                }), /// _lendingTermReferences
                 1, // _gaugeType
                 addresses.mainnet("CORE"), // _core
                 addresses.mainnet("TIMELOCK"), // _timelock

--- a/test/proposals/Proposal_0.sol
+++ b/test/proposals/Proposal_0.sol
@@ -125,13 +125,16 @@ contract Proposal_0 is Proposal {
                 650, // midPoint = 10m50s
                 1800 // auctionDuration = 30m
             );
-            LendingTerm termUSDC1 = new LendingTerm(
+            LendingTerm termUSDC1 = new LendingTerm();
+            termUSDC1.initialize(
                 addresses.mainnet("CORE"),
-                addresses.mainnet("PROFIT_MANAGER"),
-                addresses.mainnet("ERC20_GUILD"),
-                address(auctionHouse),
-                addresses.mainnet("RATE_LIMITED_CREDIT_MINTER"),
-                addresses.mainnet("ERC20_CREDIT"),
+                LendingTerm.LendingTermReferences({
+                    profitManager: addresses.mainnet("PROFIT_MANAGER"),
+                    guildToken: addresses.mainnet("ERC20_GUILD"),
+                    auctionHouse: address(auctionHouse),
+                    creditMinter: addresses.mainnet("RATE_LIMITED_CREDIT_MINTER"),
+                    creditToken: addresses.mainnet("ERC20_CREDIT")
+                }),
                 LendingTerm.LendingTermParams({
                     collateralToken: addresses.mainnet("ERC20_USDC"),
                     maxDebtPerCollateralToken: 1e30, // 1 CREDIT per USDC collateral + 12 decimals correction
@@ -142,13 +145,16 @@ contract Proposal_0 is Proposal {
                     hardCap: 2_000_000e18 // max 2M CREDIT issued
                 })
             );
-            LendingTerm termSDAI1 = new LendingTerm(
+            LendingTerm termSDAI1 = new LendingTerm();
+            termSDAI1.initialize(
                 addresses.mainnet("CORE"),
-                addresses.mainnet("PROFIT_MANAGER"),
-                addresses.mainnet("ERC20_GUILD"),
-                address(auctionHouse),
-                addresses.mainnet("RATE_LIMITED_CREDIT_MINTER"),
-                addresses.mainnet("ERC20_CREDIT"),
+                LendingTerm.LendingTermReferences({
+                    profitManager: addresses.mainnet("PROFIT_MANAGER"),
+                    guildToken: addresses.mainnet("ERC20_GUILD"),
+                    auctionHouse: address(auctionHouse),
+                    creditMinter: addresses.mainnet("RATE_LIMITED_CREDIT_MINTER"),
+                    creditToken: addresses.mainnet("ERC20_CREDIT")
+                }),
                 LendingTerm.LendingTermParams({
                     collateralToken: addresses.mainnet("ERC20_SDAI"),
                     maxDebtPerCollateralToken: 1e18, // 1 CREDIT per SDAI collateral + no decimals correction

--- a/test/proposals/Proposal_0.sol
+++ b/test/proposals/Proposal_0.sol
@@ -18,6 +18,7 @@ import {ProfitManager} from "@src/governance/ProfitManager.sol";
 import {VoltVetoGovernor} from "@src/governance/VoltVetoGovernor.sol";
 import {RateLimitedMinter} from "@src/rate-limits/RateLimitedMinter.sol";
 import {SurplusGuildMinter} from "@src/loan/SurplusGuildMinter.sol";
+import {LendingTermOnboarding} from "@src/governance/LendingTermOnboarding.sol";
 import {VoltTimelockController} from "@src/governance/VoltTimelockController.sol";
 import {LendingTermOffboarding} from "@src/governance/LendingTermOffboarding.sol";
 
@@ -78,6 +79,39 @@ contract Proposal_0 is Proposal {
             addresses.addMainnet("SURPLUS_GUILD_MINTER", address(guildMinter));
         }
 
+        // Auction House & LendingTerm Implementation V1
+        {
+            AuctionHouse auctionHouse = new AuctionHouse(
+                addresses.mainnet("CORE"),
+                650, // midPoint = 10m50s
+                1800 // auctionDuration = 30m
+            );
+
+            LendingTerm termV1 = new LendingTerm();
+            termV1.initialize(
+                addresses.mainnet("CORE"),
+                LendingTerm.LendingTermReferences({
+                    profitManager: addresses.mainnet("PROFIT_MANAGER"),
+                    guildToken: addresses.mainnet("ERC20_GUILD"),
+                    auctionHouse: address(auctionHouse),
+                    creditMinter: addresses.mainnet("RATE_LIMITED_CREDIT_MINTER"),
+                    creditToken: addresses.mainnet("ERC20_CREDIT")
+                }),
+                LendingTerm.LendingTermParams({
+                    collateralToken: address(0),
+                    maxDebtPerCollateralToken: 0,
+                    interestRate: 0,
+                    maxDelayBetweenPartialRepay: 0,
+                    minPartialRepayPercent: 0,
+                    openingFee: 0,
+                    hardCap: 0
+                })
+            );
+
+            addresses.addMainnet("AUCTION_HOUSE_1", address(auctionHouse));
+            addresses.addMainnet("LENDING_TERM_V1", address(termV1));
+        }
+
         // Governance
         {
             VoltTimelockController timelock = new VoltTimelockController(
@@ -104,14 +138,26 @@ contract Proposal_0 is Proposal {
                 addresses.mainnet("ERC20_GUILD"),
                 5_000_000e18 // quorum
             );
+            LendingTermOnboarding termOnboarding = new LendingTermOnboarding(
+                addresses.mainnet("LENDING_TERM_V1"), // _lendingTermImplementation
+                addresses.mainnet("ERC20_GUILD"), // _guildToken
+                1, // _gaugeType
+                addresses.mainnet("CORE"), // _core
+                addresses.mainnet("TIMELOCK"), // _timelock
+                0, // initialVotingDelay
+                7000 * 3, // initialVotingPeriod (~7000 blocks/day)
+                2_500_000e18, // initialProposalThreshold
+                10_000_000e18 // initialQuorum
+            );
 
             addresses.addMainnet("TIMELOCK", address(timelock));
             addresses.addMainnet("GOVERNOR", address(governor));
             addresses.addMainnet("VETO_GOVERNOR", address(vetoGovernor));
             addresses.addMainnet("LENDING_TERM_OFFBOARDING", address(termOffboarding));
+            addresses.addMainnet("LENDING_TERM_ONBOARDING", address(termOnboarding));
         }
 
-        // Terms & Auction House
+        // Terms & PSM
         {
             SimplePSM psm = new SimplePSM(
                 addresses.mainnet("CORE"),
@@ -120,55 +166,32 @@ contract Proposal_0 is Proposal {
                 addresses.mainnet("ERC20_CREDIT"),
                 addresses.mainnet("ERC20_USDC")
             );
-            AuctionHouse auctionHouse = new AuctionHouse(
-                addresses.mainnet("CORE"),
-                650, // midPoint = 10m50s
-                1800 // auctionDuration = 30m
+
+            LendingTermOnboarding termOnboarding = LendingTermOnboarding(
+                payable(addresses.mainnet("LENDING_TERM_ONBOARDING"))
             );
-            LendingTerm termUSDC1 = new LendingTerm();
-            termUSDC1.initialize(
-                addresses.mainnet("CORE"),
-                LendingTerm.LendingTermReferences({
-                    profitManager: addresses.mainnet("PROFIT_MANAGER"),
-                    guildToken: addresses.mainnet("ERC20_GUILD"),
-                    auctionHouse: address(auctionHouse),
-                    creditMinter: addresses.mainnet("RATE_LIMITED_CREDIT_MINTER"),
-                    creditToken: addresses.mainnet("ERC20_CREDIT")
-                }),
-                LendingTerm.LendingTermParams({
-                    collateralToken: addresses.mainnet("ERC20_USDC"),
-                    maxDebtPerCollateralToken: 1e30, // 1 CREDIT per USDC collateral + 12 decimals correction
-                    interestRate: 0, // 0%
-                    maxDelayBetweenPartialRepay: 0,// no periodic partial repay needed
-                    minPartialRepayPercent: 0, // no minimum size for partial repay
-                    openingFee: 0, // 0%
-                    hardCap: 2_000_000e18 // max 2M CREDIT issued
-                })
-            );
-            LendingTerm termSDAI1 = new LendingTerm();
-            termSDAI1.initialize(
-                addresses.mainnet("CORE"),
-                LendingTerm.LendingTermReferences({
-                    profitManager: addresses.mainnet("PROFIT_MANAGER"),
-                    guildToken: addresses.mainnet("ERC20_GUILD"),
-                    auctionHouse: address(auctionHouse),
-                    creditMinter: addresses.mainnet("RATE_LIMITED_CREDIT_MINTER"),
-                    creditToken: addresses.mainnet("ERC20_CREDIT")
-                }),
-                LendingTerm.LendingTermParams({
-                    collateralToken: addresses.mainnet("ERC20_SDAI"),
-                    maxDebtPerCollateralToken: 1e18, // 1 CREDIT per SDAI collateral + no decimals correction
-                    interestRate: 0.03e18, // 3%
-                    maxDelayBetweenPartialRepay: 0,// no periodic partial repay needed
-                    minPartialRepayPercent: 0, // no minimum size for partial repay
-                    openingFee: 0, // 0%
-                    hardCap: 2_000_000e18 // max 2M CREDIT issued
-                })
-            );
+            address termUSDC1 = termOnboarding.createTerm(LendingTerm.LendingTermParams({
+                collateralToken: addresses.mainnet("ERC20_USDC"),
+                maxDebtPerCollateralToken: 1e30, // 1 CREDIT per USDC collateral + 12 decimals correction
+                interestRate: 0, // 0%
+                maxDelayBetweenPartialRepay: 0,// no periodic partial repay needed
+                minPartialRepayPercent: 0, // no minimum size for partial repay
+                openingFee: 0, // 0%
+                hardCap: 2_000_000e18 // max 2M CREDIT issued
+            }));
+            address termSDAI1 = termOnboarding.createTerm(LendingTerm.LendingTermParams({
+                collateralToken: addresses.mainnet("ERC20_SDAI"),
+                maxDebtPerCollateralToken: 1e18, // 1 CREDIT per SDAI collateral + no decimals correction
+                interestRate: 0.03e18, // 3%
+                maxDelayBetweenPartialRepay: 0,// no periodic partial repay needed
+                minPartialRepayPercent: 0, // no minimum size for partial repay
+                openingFee: 0, // 0%
+                hardCap: 2_000_000e18 // max 2M CREDIT issued
+            }));
+
             addresses.addMainnet("PSM_USDC", address(psm));
-            addresses.addMainnet("AUCTION_HOUSE_1", address(auctionHouse));
-            addresses.addMainnet("TERM_USDC_1", address(termUSDC1));
-            addresses.addMainnet("TERM_SDAI_1", address(termSDAI1));
+            addresses.addMainnet("TERM_USDC_1", termUSDC1);
+            addresses.addMainnet("TERM_SDAI_1", termSDAI1);
         }
     }
 
@@ -229,6 +252,7 @@ contract Proposal_0 is Proposal {
 
         // TIMELOCK_PROPOSER
         core.grantRole(CoreRoles.TIMELOCK_PROPOSER, addresses.mainnet("GOVERNOR"));
+        core.grantRole(CoreRoles.TIMELOCK_PROPOSER, addresses.mainnet("LENDING_TERM_ONBOARDING"));
         core.grantRole(CoreRoles.TIMELOCK_PROPOSER, addresses.mainnet("TEAM_MULTISIG"));
 
         // TIMELOCK_EXECUTOR

--- a/test/unit/governance/LendingTermOffboarding.t.sol
+++ b/test/unit/governance/LendingTermOffboarding.t.sol
@@ -328,4 +328,37 @@ contract LendingTermOffboardingUnitTest is Test {
         assertEq(offboarder.polls(snapshotBlock, address(term)), _QUORUM / 2 + 1);
         assertEq(offboarder.canOffboard(address(term)), false);
     }
+
+    function testCannotCleanupAfterReonboard() public {
+        // prepare (1)
+        guild.mint(bob, _QUORUM);
+        vm.startPrank(bob);
+        guild.delegate(bob);
+        uint256 snapshotBlock = block.number;
+        offboarder.proposeOffboard(address(term));
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+        offboarder.supportOffboard(snapshotBlock, address(term));
+        offboarder.offboard(address(term));
+
+        // get enough CREDIT to pack back interests
+        vm.stopPrank();
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+        uint256 debt = term.getLoanDebt(aliceLoanId);
+        credit.mint(alice, debt - aliceLoanSize);
+
+        // close loans
+        vm.startPrank(alice);
+        credit.approve(address(term), debt);
+        term.repay(aliceLoanId);
+        vm.stopPrank();
+
+        // re-onboard
+        guild.addGauge(1, address(term));
+
+        // cleanup
+        vm.expectRevert("LendingTermOffboarding: re-onboarded");
+        offboarder.cleanup(address(term));
+    }
 }

--- a/test/unit/governance/LendingTermOffboarding.t.sol
+++ b/test/unit/governance/LendingTermOffboarding.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.13;
 
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
 import {Test} from "@forge-std/Test.sol";
 import {Core} from "@src/core/Core.sol";
 import {CoreRoles} from "@src/core/CoreRoles.sol";
@@ -63,7 +65,7 @@ contract LendingTermOffboardingUnitTest is Test {
             650,
             1800
         );
-        term = new LendingTerm();
+        term = LendingTerm(Clones.clone(address(new LendingTerm())));
         term.initialize(
             address(core),
             LendingTerm.LendingTermReferences({

--- a/test/unit/governance/LendingTermOffboarding.t.sol
+++ b/test/unit/governance/LendingTermOffboarding.t.sol
@@ -294,7 +294,6 @@ contract LendingTermOffboardingUnitTest is Test {
         offboarder.cleanup(address(term));
 
         assertEq(offboarder.canOffboard(address(term)), false);
-        assertEq(term.hardCap(), 0);
         assertEq(core.hasRole(CoreRoles.GAUGE_PNL_NOTIFIER, address(term)), false);
         assertEq(core.hasRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, address(term)), false);
     }

--- a/test/unit/governance/LendingTermOffboarding.t.sol
+++ b/test/unit/governance/LendingTermOffboarding.t.sol
@@ -63,13 +63,16 @@ contract LendingTermOffboardingUnitTest is Test {
             650,
             1800
         );
-        term = new LendingTerm(
-            address(core), /*_core*/
-            address(profitManager), /*_profitManager*/
-            address(guild), /*_guildToken*/
-            address(auctionHouse), /*_auctionHouse*/
-            address(rlcm), /*_creditMinter*/
-            address(credit), /*_creditToken*/
+        term = new LendingTerm();
+        term.initialize(
+            address(core),
+            LendingTerm.LendingTermReferences({
+                profitManager: address(profitManager),
+                guildToken: address(guild),
+                auctionHouse: address(auctionHouse),
+                creditMinter: address(rlcm),
+                creditToken: address(credit)
+            }),
             LendingTerm.LendingTermParams({
                 collateralToken: address(collateral),
                 maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,

--- a/test/unit/governance/LendingTermOnboarding.t.sol
+++ b/test/unit/governance/LendingTermOnboarding.t.sol
@@ -72,32 +72,19 @@ contract LendingTermOnboardingUnitTest is Test {
             1800
         );
         termImplementation = new LendingTerm();
-        termImplementation.initialize(
-            address(core),
-            LendingTerm.LendingTermReferences({
-                profitManager: address(profitManager),
-                guildToken: address(guild),
-                auctionHouse: address(auctionHouse),
-                creditMinter: address(rlcm),
-                creditToken: address(credit)
-            }),
-            LendingTerm.LendingTermParams({
-                collateralToken: address(0),
-                maxDebtPerCollateralToken: 0,
-                interestRate: 0,
-                maxDelayBetweenPartialRepay: 0,
-                minPartialRepayPercent: 0,
-                openingFee: 0,
-                hardCap: 0
-            })
-        );
         timelock = new VoltTimelockController(
             address(core),
             _TIMELOCK_MIN_DELAY
         );
         onboarder = new LendingTermOnboarding(
             address(termImplementation), // _lendingTermImplementation
-            address(guild), // _guildToken
+            LendingTerm.LendingTermReferences({
+                profitManager: address(profitManager),
+                guildToken: address(guild),
+                auctionHouse: address(auctionHouse),
+                creditMinter: address(rlcm),
+                creditToken: address(credit)
+            }), /// _lendingTermReferences
             1, // _gaugeType
             address(core), // _core
             address(timelock), // _timelock
@@ -176,7 +163,7 @@ contract LendingTermOnboardingUnitTest is Test {
             hardCap: _HARDCAP
         })));
         vm.label(address(term), "term");
-        assertEq(address(term.core()), address(termImplementation.core()));
+        assertEq(address(term.core()), address(onboarder.core()));
 
         LendingTerm.LendingTermReferences memory refs = term.getReferences();
         assertEq(refs.profitManager, address(profitManager));
@@ -213,7 +200,7 @@ contract LendingTermOnboardingUnitTest is Test {
         // propose onboard
         vm.prank(alice);
         vm.expectRevert("Pausable: paused");
-        uint256 proposalId = onboarder.proposeOnboard(address(this));
+        onboarder.proposeOnboard(address(this));
     }
 
     function testProposeOnboard() public {

--- a/test/unit/governance/LendingTermOnboarding.t.sol
+++ b/test/unit/governance/LendingTermOnboarding.t.sol
@@ -184,6 +184,79 @@ contract LendingTermOnboardingUnitTest is Test {
         assertEq(onboarder.created(address(term)), block.timestamp);
     }
 
+    function testCreateCheckParams() public {
+        vm.expectRevert("LendingTermOnboarding: invalid collateralToken");
+        LendingTerm(onboarder.createTerm(LendingTerm.LendingTermParams({
+            collateralToken: address(0), // not a token
+            maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
+            interestRate: _INTEREST_RATE,
+            maxDelayBetweenPartialRepay: 123,
+            minPartialRepayPercent: 456,
+            openingFee: 789,
+            hardCap: _HARDCAP
+        })));
+        vm.expectRevert("LendingTermOnboarding: invalid maxDebtPerCollateralToken");
+        LendingTerm(onboarder.createTerm(LendingTerm.LendingTermParams({
+            collateralToken: address(collateral),
+            maxDebtPerCollateralToken: 0, // no debt available
+            interestRate: _INTEREST_RATE,
+            maxDelayBetweenPartialRepay: 123,
+            minPartialRepayPercent: 456,
+            openingFee: 789,
+            hardCap: _HARDCAP
+        })));
+        vm.expectRevert("LendingTermOnboarding: invalid interestRate");
+        LendingTerm(onboarder.createTerm(LendingTerm.LendingTermParams({
+            collateralToken: address(collateral),
+            maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
+            interestRate: 1e18, // 100% APR is too high
+            maxDelayBetweenPartialRepay: 123,
+            minPartialRepayPercent: 456,
+            openingFee: 789,
+            hardCap: _HARDCAP
+        })));
+        vm.expectRevert("LendingTermOnboarding: invalid maxDelayBetweenPartialRepay");
+        LendingTerm(onboarder.createTerm(LendingTerm.LendingTermParams({
+            collateralToken: address(collateral),
+            maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
+            interestRate: _INTEREST_RATE,
+            maxDelayBetweenPartialRepay: 2 * 365 * 24 * 3600, // 2 years between payments is too long
+            minPartialRepayPercent: 456,
+            openingFee: 789,
+            hardCap: _HARDCAP
+        })));
+        vm.expectRevert("LendingTermOnboarding: invalid minPartialRepayPercent");
+        LendingTerm(onboarder.createTerm(LendingTerm.LendingTermParams({
+            collateralToken: address(collateral),
+            maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
+            interestRate: _INTEREST_RATE,
+            maxDelayBetweenPartialRepay: 123,
+            minPartialRepayPercent: 1e18, // min repay of 100% is too high
+            openingFee: 789,
+            hardCap: _HARDCAP
+        })));
+        vm.expectRevert("LendingTermOnboarding: invalid openingFee");
+        LendingTerm(onboarder.createTerm(LendingTerm.LendingTermParams({
+            collateralToken: address(collateral),
+            maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
+            interestRate: _INTEREST_RATE,
+            maxDelayBetweenPartialRepay: 123,
+            minPartialRepayPercent: 456,
+            openingFee: 1e18, // 100% opening fee is too high
+            hardCap: _HARDCAP
+        })));
+        vm.expectRevert("LendingTermOnboarding: invalid hardCap");
+        LendingTerm(onboarder.createTerm(LendingTerm.LendingTermParams({
+            collateralToken: address(collateral),
+            maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
+            interestRate: _INTEREST_RATE,
+            maxDelayBetweenPartialRepay: 123,
+            minPartialRepayPercent: 456,
+            openingFee: 789,
+            hardCap: 0 // hardCap of 0 makes no debt available
+        })));
+    }
+
     function testProposeArbitraryCallsReverts() public {
         address[] memory targets = new address[](1);
         uint256[] memory values = new uint256[](1);

--- a/test/unit/governance/LendingTermOnboarding.t.sol
+++ b/test/unit/governance/LendingTermOnboarding.t.sol
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.13;
+
+import {Governor, IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";
+import {GovernorCountingSimple} from "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol";
+
+import {Test} from "@forge-std/Test.sol";
+import {Core} from "@src/core/Core.sol";
+import {CoreRoles} from "@src/core/CoreRoles.sol";
+import {MockERC20} from "@test/mock/MockERC20.sol";
+import {GuildToken} from "@src/tokens/GuildToken.sol";
+import {CreditToken} from "@src/tokens/CreditToken.sol";
+import {LendingTerm} from "@src/loan/LendingTerm.sol";
+import {AuctionHouse} from "@src/loan/AuctionHouse.sol";
+import {ProfitManager} from "@src/governance/ProfitManager.sol";
+import {RateLimitedMinter} from "@src/rate-limits/RateLimitedMinter.sol";
+import {LendingTermOnboarding} from "@src/governance/LendingTermOnboarding.sol";
+import {VoltTimelockController} from "@src/governance/VoltTimelockController.sol";
+
+contract LendingTermOnboardingUnitTest is Test {
+    address private governor = address(1);
+    Core private core;
+    ProfitManager private profitManager;
+    GuildToken private guild;
+    CreditToken private credit;
+    MockERC20 private collateral;
+    LendingTerm private termImplementation;
+    AuctionHouse auctionHouse;
+    RateLimitedMinter rlcm;
+    VoltTimelockController private timelock;
+    LendingTermOnboarding private onboarder;
+    address private constant alice = address(0x616c696365);
+    address private constant bob = address(0xB0B);
+
+    // VoltTimelockController params
+    uint256 private constant _TIMELOCK_MIN_DELAY = 3600; // 1h
+
+    // LendingTerm params
+    uint256 private constant _CREDIT_PER_COLLATERAL_TOKEN = 1e18; // 1:1, same decimals
+    uint256 private constant _INTEREST_RATE = 0.05e18; // 5% APR
+    uint256 private constant _HARDCAP = 1_000_000e18;
+
+    // LendingTermOnboarding params
+    uint256 private constant _VOTING_DELAY = 0;
+    uint256 private constant _VOTING_PERIOD = 100_000; // ~14 days
+    uint256 private constant _PROPOSAL_THRESHOLD = 2_500_000e18;
+    uint256 private constant _QUORUM = 20_000_000e18;
+
+    function setUp() public {
+        vm.warp(1679067867);
+        vm.roll(16848497);
+
+        // deploy
+        core = new Core();
+        profitManager = new ProfitManager(address(core));
+        credit = new CreditToken(address(core));
+        guild = new GuildToken(address(core), address(profitManager), address(credit));
+        profitManager.initializeReferences(address(credit), address(guild));
+        collateral = new MockERC20();
+        rlcm = new RateLimitedMinter(
+            address(core), /*_core*/
+            address(credit), /*_token*/
+            CoreRoles.RATE_LIMITED_CREDIT_MINTER, /*_role*/
+            type(uint256).max, /*_maxRateLimitPerSecond*/
+            type(uint128).max, /*_rateLimitPerSecond*/
+            type(uint128).max /*_bufferCap*/
+        );
+        auctionHouse = new AuctionHouse(
+            address(core),
+            650,
+            1800
+        );
+        termImplementation = new LendingTerm();
+        termImplementation.initialize(
+            address(core),
+            LendingTerm.LendingTermReferences({
+                profitManager: address(profitManager),
+                guildToken: address(guild),
+                auctionHouse: address(auctionHouse),
+                creditMinter: address(rlcm),
+                creditToken: address(credit)
+            }),
+            LendingTerm.LendingTermParams({
+                collateralToken: address(0),
+                maxDebtPerCollateralToken: 0,
+                interestRate: 0,
+                maxDelayBetweenPartialRepay: 0,
+                minPartialRepayPercent: 0,
+                openingFee: 0,
+                hardCap: 0
+            })
+        );
+        timelock = new VoltTimelockController(
+            address(core),
+            _TIMELOCK_MIN_DELAY
+        );
+        onboarder = new LendingTermOnboarding(
+            address(termImplementation), // _lendingTermImplementation
+            address(guild), // _guildToken
+            1, // _gaugeType
+            address(core), // _core
+            address(timelock), // _timelock
+            address(guild), // _token
+            _VOTING_DELAY, // initialVotingDelay
+            _VOTING_PERIOD, // initialVotingPeriod
+            _PROPOSAL_THRESHOLD, // initialProposalThreshold
+            _QUORUM // initialQuorum
+        );
+        
+        // permissions
+        core.grantRole(CoreRoles.GOVERNOR, governor);
+        core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
+        core.grantRole(CoreRoles.GUILD_MINTER, address(this));
+        core.grantRole(CoreRoles.GAUGE_ADD, address(this));
+        core.grantRole(CoreRoles.GAUGE_REMOVE, address(this));
+        core.grantRole(CoreRoles.GAUGE_PARAMETERS, address(this));
+        core.grantRole(CoreRoles.GUILD_GOVERNANCE_PARAMETERS, address(this));
+        core.grantRole(CoreRoles.CREDIT_MINTER, address(rlcm));
+        core.grantRole(CoreRoles.GOVERNOR, address(timelock));
+        core.grantRole(CoreRoles.GAUGE_ADD, address(timelock));
+        core.grantRole(CoreRoles.TIMELOCK_EXECUTOR, address(0));
+        core.grantRole(CoreRoles.TIMELOCK_PROPOSER, address(onboarder));
+        core.renounceRole(CoreRoles.GOVERNOR, address(this));
+
+        // allow GUILD gauge votes & delegations
+        guild.setMaxGauges(10);
+        guild.setMaxDelegates(10);
+
+        // labels
+        vm.label(address(this), "test");
+        vm.label(address(core), "core");
+        vm.label(address(profitManager), "profitManager");
+        vm.label(address(guild), "guild");
+        vm.label(address(credit), "credit");
+        vm.label(address(rlcm), "rlcm");
+        vm.label(address(timelock), "timelock");
+        vm.label(address(auctionHouse), "auctionHouse");
+        vm.label(address(termImplementation), "termImplementation");
+        vm.label(address(onboarder), "onboarder");
+        vm.label(alice, "alice");
+        vm.label(bob, "bob");
+    }
+
+    function testInitialState() public {
+        assertEq(onboarder.lendingTermImplementation(), address(termImplementation));
+        
+        assertEq(onboarder.timelock(), address(timelock));
+        assertEq(onboarder.votingDelay(), _VOTING_DELAY);
+        assertEq(onboarder.votingPeriod(), _VOTING_PERIOD);
+        assertEq(onboarder.proposalThreshold(), _PROPOSAL_THRESHOLD);
+        assertEq(onboarder.quorum(0), _QUORUM);
+        assertEq(onboarder.COUNTING_MODE(), "support=bravo&quorum=for,abstain");
+        assertEq(address(onboarder.token()), address(guild));
+        assertEq(onboarder.name(), "Volt Protocol Governor");
+        assertEq(onboarder.version(), "1");
+    }
+
+    function testSetQuorum() public {
+        vm.expectRevert("UNAUTHORIZED");
+        onboarder.setQuorum(_QUORUM * 2);
+
+        vm.prank(governor);
+        onboarder.setQuorum(_QUORUM * 2);
+        assertEq(onboarder.quorum(0), _QUORUM * 2);
+    }
+
+    function testCreateTerm() public {
+        LendingTerm term = LendingTerm(onboarder.createTerm(LendingTerm.LendingTermParams({
+            collateralToken: address(collateral),
+            maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
+            interestRate: _INTEREST_RATE,
+            maxDelayBetweenPartialRepay: 123,
+            minPartialRepayPercent: 456,
+            openingFee: 789,
+            hardCap: _HARDCAP
+        })));
+        vm.label(address(term), "term");
+        assertEq(address(term.core()), address(termImplementation.core()));
+
+        LendingTerm.LendingTermReferences memory refs = term.getReferences();
+        assertEq(refs.profitManager, address(profitManager));
+        assertEq(refs.guildToken, address(guild));
+        assertEq(refs.auctionHouse, address(auctionHouse));
+        assertEq(refs.creditMinter, address(rlcm));
+        assertEq(refs.creditToken, address(credit));
+
+        LendingTerm.LendingTermParams memory params = term.getParameters();
+        assertEq(params.collateralToken, address(collateral));
+        assertEq(params.maxDebtPerCollateralToken, _CREDIT_PER_COLLATERAL_TOKEN);
+        assertEq(params.interestRate, _INTEREST_RATE);
+        assertEq(params.maxDelayBetweenPartialRepay, 123);
+        assertEq(params.minPartialRepayPercent, 456);
+        assertEq(params.openingFee, 789);
+        assertEq(params.hardCap, _HARDCAP);
+
+        assertEq(onboarder.created(address(term)), block.timestamp);
+    }
+
+    function testProposeArbitraryCallsReverts() public {
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory payloads = new bytes[](1);
+        vm.expectRevert("LendingTermOnboarding: cannot propose arbitrary actions");
+        onboarder.propose(targets, values, payloads, "test");
+    }
+
+    function testProposeOnboard() public {
+        LendingTerm term = LendingTerm(onboarder.createTerm(LendingTerm.LendingTermParams({
+            collateralToken: address(collateral),
+            maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
+            interestRate: _INTEREST_RATE,
+            maxDelayBetweenPartialRepay: 0,
+            minPartialRepayPercent: 0,
+            openingFee: 0,
+            hardCap: _HARDCAP
+        })));
+        vm.label(address(term), "term");
+        
+        // cannot propose an arbitrary address (must come from factory)
+        vm.expectRevert("LendingTermOnboarding: invalid term");
+        onboarder.proposeOnboard(address(this));
+
+        // cannot propose if the user doesn't have enough GUILD
+        vm.expectRevert("Governor: proposer votes below proposal threshold");
+        onboarder.proposeOnboard(address(term));
+
+        // mint GUILD & self delegate
+        guild.mint(alice, _PROPOSAL_THRESHOLD);
+        guild.mint(bob, _QUORUM);
+        vm.prank(alice);
+        guild.delegate(alice);
+        vm.prank(bob);
+        guild.incrementDelegation(bob, _QUORUM);
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+
+        // propose onboard
+        vm.prank(alice);
+        uint256 proposalId = onboarder.proposeOnboard(address(term));
+
+        // cannot propose the same term multiple times in a short interval of time
+        vm.expectRevert("LendingTermOnboarding: recently proposed");
+        onboarder.proposeOnboard(address(term));
+
+        // check proposal creation
+        assertEq(uint8(onboarder.state(proposalId)), uint8(IGovernor.ProposalState.Pending));
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+        assertEq(uint8(onboarder.state(proposalId)), uint8(IGovernor.ProposalState.Active));
+
+        // support & check status
+        vm.prank(bob);
+        onboarder.castVote(proposalId, uint8(GovernorCountingSimple.VoteType.For));
+        vm.roll(block.number + _VOTING_PERIOD + 1);
+        vm.warp(block.timestamp + 13);
+        assertEq(uint8(onboarder.state(proposalId)), uint8(IGovernor.ProposalState.Succeeded));
+
+        // queue
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+        (
+            address[] memory targets,
+            uint256[] memory values,
+            bytes[] memory calldatas,
+            string memory description
+        ) = onboarder.getOnboardProposeArgs(address(term));
+        onboarder.queue(targets, values, calldatas, keccak256(bytes(description)));
+        assertEq(uint8(onboarder.state(proposalId)), uint8(IGovernor.ProposalState.Queued));
+
+        // execute
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + _TIMELOCK_MIN_DELAY + 13);
+        onboarder.execute(targets, values, calldatas, keccak256(bytes(description)));
+        assertEq(uint8(onboarder.state(proposalId)), uint8(IGovernor.ProposalState.Executed));
+
+        // check execution
+        assertEq(guild.isGauge(address(term)), true);
+
+        // cannot propose the same term twice if it's already active
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 7 days + 13);
+        vm.expectRevert("LendingTermOnboarding: active term");
+        onboarder.proposeOnboard(address(term));
+
+        // vote for the term
+        guild.mint(address(this), 1e18);
+        guild.incrementGauge(address(term), 1e18);
+
+        // do a borrow
+        collateral.mint(address(this), 1e24);
+        collateral.approve(address(term), 1e24);
+        term.borrow(1e24, 1e24);
+        assertEq(collateral.balanceOf(address(this)), 0);
+        assertEq(collateral.balanceOf(address(term)), 1e24);
+        assertEq(credit.balanceOf(address(this)), 1e24);
+    }
+}

--- a/test/unit/governance/LendingTermOnboarding.t.sol
+++ b/test/unit/governance/LendingTermOnboarding.t.sol
@@ -100,7 +100,6 @@ contract LendingTermOnboardingUnitTest is Test {
             1, // _gaugeType
             address(core), // _core
             address(timelock), // _timelock
-            address(guild), // _token
             _VOTING_DELAY, // initialVotingDelay
             _VOTING_PERIOD, // initialVotingPeriod
             _PROPOSAL_THRESHOLD, // initialProposalThreshold

--- a/test/unit/governance/LendingTermOnboarding.t.sol
+++ b/test/unit/governance/LendingTermOnboarding.t.sol
@@ -19,6 +19,7 @@ import {VoltTimelockController} from "@src/governance/VoltTimelockController.sol
 
 contract LendingTermOnboardingUnitTest is Test {
     address private governor = address(1);
+    address private guardian = address(2);
     Core private core;
     ProfitManager private profitManager;
     GuildToken private guild;
@@ -108,6 +109,7 @@ contract LendingTermOnboardingUnitTest is Test {
         
         // permissions
         core.grantRole(CoreRoles.GOVERNOR, governor);
+        core.grantRole(CoreRoles.GUARDIAN, guardian);
         core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
         core.grantRole(CoreRoles.GUILD_MINTER, address(this));
         core.grantRole(CoreRoles.GAUGE_ADD, address(this));
@@ -201,6 +203,17 @@ contract LendingTermOnboardingUnitTest is Test {
         bytes[] memory payloads = new bytes[](1);
         vm.expectRevert("LendingTermOnboarding: cannot propose arbitrary actions");
         onboarder.propose(targets, values, payloads, "test");
+    }
+
+    function testProposeOnboardPausable() public {
+        // pause term
+        vm.prank(guardian);
+        onboarder.pause();
+
+        // propose onboard
+        vm.prank(alice);
+        vm.expectRevert("Pausable: paused");
+        uint256 proposalId = onboarder.proposeOnboard(address(this));
     }
 
     function testProposeOnboard() public {

--- a/test/unit/loan/AuctionHouse.t.sol
+++ b/test/unit/loan/AuctionHouse.t.sol
@@ -53,13 +53,16 @@ contract AuctionHouseUnitTest is Test {
             _MIDPOINT,
             _AUCTION_DURATION
         );
-        term = new LendingTerm(
-            address(core), /*_core*/
-            address(profitManager), /*_profitManager*/
-            address(guild), /*_guildToken*/
-            address(auctionHouse), /*_auctionHouse*/
-            address(rlcm), /*_creditMinter*/
-            address(credit), /*_creditToken*/
+        term = new LendingTerm();
+        term.initialize(
+            address(core),
+            LendingTerm.LendingTermReferences({
+                profitManager: address(profitManager),
+                guildToken: address(guild),
+                auctionHouse: address(auctionHouse),
+                creditMinter: address(rlcm),
+                creditToken: address(credit)
+            }),
             LendingTerm.LendingTermParams({
                 collateralToken: address(collateral),
                 maxDebtPerCollateralToken: 2000e18, // 2000, same decimals

--- a/test/unit/loan/AuctionHouse.t.sol
+++ b/test/unit/loan/AuctionHouse.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.13;
 
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
 import {Test} from "@forge-std/Test.sol";
 import {Core} from "@src/core/Core.sol";
 import {CoreRoles} from "@src/core/CoreRoles.sol";
@@ -53,7 +55,7 @@ contract AuctionHouseUnitTest is Test {
             _MIDPOINT,
             _AUCTION_DURATION
         );
-        term = new LendingTerm();
+        term = LendingTerm(Clones.clone(address(new LendingTerm())));
         term.initialize(
             address(core),
             LendingTerm.LendingTermReferences({

--- a/test/unit/loan/LendingTerm.t.sol
+++ b/test/unit/loan/LendingTerm.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.13;
 
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
 import {Test} from "@forge-std/Test.sol";
 import {Core} from "@src/core/Core.sol";
 import {CoreRoles} from "@src/core/CoreRoles.sol";
@@ -53,7 +55,7 @@ contract LendingTermUnitTest is Test {
             650,
             1800
         );
-        term = new LendingTerm();
+        term = LendingTerm(Clones.clone(address(new LendingTerm())));
         term.initialize(
             address(core),
             LendingTerm.LendingTermReferences({
@@ -168,7 +170,7 @@ contract LendingTermUnitTest is Test {
     // borrow with opening fee success
     function testBorrowWithOpeningFeeSuccess() public {
         // create a similar term but with 5% opening fee
-        LendingTerm term2 = new LendingTerm();
+        LendingTerm term2 = LendingTerm(Clones.clone(address(new LendingTerm())));
         term2.initialize(
             address(core),
             term.getReferences(),

--- a/test/unit/loan/LendingTerm.t.sol
+++ b/test/unit/loan/LendingTerm.t.sol
@@ -53,13 +53,16 @@ contract LendingTermUnitTest is Test {
             650,
             1800
         );
-        term = new LendingTerm(
-            address(core), /*_core*/
-            address(profitManager), /*_profitManager*/
-            address(guild), /*_guildToken*/
-            address(auctionHouse), /*_auctionHouse*/
-            address(rlcm), /*_creditMinter*/
-            address(credit), /*_creditToken*/
+        term = new LendingTerm();
+        term.initialize(
+            address(core),
+            LendingTerm.LendingTermReferences({
+                profitManager: address(profitManager),
+                guildToken: address(guild),
+                auctionHouse: address(auctionHouse),
+                creditMinter: address(rlcm),
+                creditToken: address(credit)
+            }),
             LendingTerm.LendingTermParams({
                 collateralToken: address(collateral),
                 maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
@@ -105,16 +108,21 @@ contract LendingTermUnitTest is Test {
 
     function testInitialState() public {
         assertEq(address(term.core()), address(core));
-        assertEq(address(term.guildToken()), address(guild));
-        assertEq(address(term.auctionHouse()), address(auctionHouse));
-        assertEq(address(term.creditMinter()), address(rlcm));
-        assertEq(address(term.creditToken()), address(credit));
-        assertEq(address(term.collateralToken()), address(collateral));
-        assertEq(term.maxDebtPerCollateralToken(), _CREDIT_PER_COLLATERAL_TOKEN);
-        assertEq(term.interestRate(), _INTEREST_RATE);
-        assertEq(term.maxDelayBetweenPartialRepay(), _MAX_DELAY_BETWEEN_PARTIAL_REPAY);
-        assertEq(term.minPartialRepayPercent(), _MIN_PARTIAL_REPAY_PERCENT);
-        assertEq(term.hardCap(), _HARDCAP);
+
+        LendingTerm.LendingTermReferences memory refs = term.getReferences();
+        assertEq(refs.guildToken, address(guild));
+        assertEq(refs.auctionHouse, address(auctionHouse));
+        assertEq(refs.creditMinter, address(rlcm));
+        assertEq(refs.creditToken, address(credit));
+
+        LendingTerm.LendingTermParams memory params = term.getParameters();
+        assertEq(params.collateralToken, address(collateral));
+        assertEq(params.maxDebtPerCollateralToken, _CREDIT_PER_COLLATERAL_TOKEN);
+        assertEq(params.interestRate, _INTEREST_RATE);
+        assertEq(params.maxDelayBetweenPartialRepay, _MAX_DELAY_BETWEEN_PARTIAL_REPAY);
+        assertEq(params.minPartialRepayPercent, _MIN_PARTIAL_REPAY_PERCENT);
+        assertEq(params.hardCap, _HARDCAP);
+
         assertEq(term.issuance(), 0);
         assertEq(term.getLoan(bytes32(0)).borrowTime, 0);
         assertEq(term.getLoanDebt(bytes32(0)), 0);
@@ -160,13 +168,10 @@ contract LendingTermUnitTest is Test {
     // borrow with opening fee success
     function testBorrowWithOpeningFeeSuccess() public {
         // create a similar term but with 5% opening fee
-        LendingTerm term2 = new LendingTerm(
-            address(core), /*_core*/
-            address(profitManager), /*profitManager*/
-            address(guild), /*_guildToken*/
-            address(auctionHouse), /*_auctionHouse*/
-            address(rlcm), /*_creditMinter*/
-            address(credit), /*_creditToken*/
+        LendingTerm term2 = new LendingTerm();
+        term2.initialize(
+            address(core),
+            term.getReferences(),
             LendingTerm.LendingTermParams({
                 collateralToken: address(collateral),
                 maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
@@ -759,12 +764,12 @@ contract LendingTermUnitTest is Test {
 
     // test governor-only setter for auctionHouse
     function testGovernorSetAuctionHouse() public {
-        assertEq(term.auctionHouse(), address(auctionHouse));
+        assertEq(term.getReferences().auctionHouse, address(auctionHouse));
         
         vm.prank(governor);
         term.setAuctionHouse(address(this));
 
-        assertEq(term.auctionHouse(), address(this));
+        assertEq(term.getReferences().auctionHouse, address(this));
 
         vm.expectRevert("UNAUTHORIZED");
         term.setAuctionHouse(address(auctionHouse));
@@ -772,12 +777,12 @@ contract LendingTermUnitTest is Test {
 
     // test setter for hardCap
     function testSetHardCap() public {
-        assertEq(term.hardCap(), _HARDCAP);
+        assertEq(term.getParameters().hardCap, _HARDCAP);
         
         vm.prank(governor);
         term.setHardCap(type(uint256).max);
 
-        assertEq(term.hardCap(), type(uint256).max);
+        assertEq(term.getParameters().hardCap, type(uint256).max);
 
         vm.expectRevert("UNAUTHORIZED");
         term.setHardCap(12345);

--- a/test/unit/loan/LendingTermSignatures.t.sol
+++ b/test/unit/loan/LendingTermSignatures.t.sol
@@ -58,13 +58,16 @@ contract LendingTermSignaturesUnitTest is Test {
             650,
             1800
         );
-        term = new LendingTerm(
-            address(core), /*_core*/
-            address(profitManager), /*_profitManager*/
-            address(guild), /*_guildToken*/
-            address(auctionHouse), /*_auctionHouse*/
-            address(rlcm), /*_creditMinter*/
-            address(credit), /*_creditToken*/
+        term = new LendingTerm();
+        term.initialize(
+            address(core),
+            LendingTerm.LendingTermReferences({
+                profitManager: address(profitManager),
+                guildToken: address(guild),
+                auctionHouse: address(auctionHouse),
+                creditMinter: address(rlcm),
+                creditToken: address(credit)
+            }),
             LendingTerm.LendingTermParams({
                 collateralToken: address(collateral),
                 maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,

--- a/test/unit/loan/LendingTermSignatures.t.sol
+++ b/test/unit/loan/LendingTermSignatures.t.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.13;
 
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
 import {Test} from "@forge-std/Test.sol";
 import {Core} from "@src/core/Core.sol";
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {CoreRoles} from "@src/core/CoreRoles.sol";
 import {MockERC20} from "@test/mock/MockERC20.sol";
 import {GuildToken} from "@src/tokens/GuildToken.sol";
@@ -58,7 +60,7 @@ contract LendingTermSignaturesUnitTest is Test {
             650,
             1800
         );
-        term = new LendingTerm();
+        term = LendingTerm(Clones.clone(address(new LendingTerm())));
         term.initialize(
             address(core),
             LendingTerm.LendingTermReferences({


### PR DESCRIPTION
On the model of `LendingTermOnboarding`, this PR adds a new `LendingTermOnboarding` contract that automates the governance process of onboarding new lending terms in the system.

Problem: the `LendingTerm` contract is very large, and deploying one costs as much as 3.3M gas. We want the system to support very large amounts of lending terms, so they need to be cheap to deploy/onboard.

Solution: refactor `LendingTerm` to use an initializer instead of constructor arguments for references to other protocol contracts & for lending term parameters. Lending Terms can then be deployed as cheap clone proxies and the deployment + initialization cost drops down to ~295k gas.

Tradeoff: borrowing is slightly more expensive (238->255k gas). This is because references & parameters cannot be made immutable anymore. 