### PR TITLE
LendingTerm.debtCeiling() getter

### DIFF
--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -266,18 +266,23 @@ contract LendingTerm is CoreRef {
     /// ceiling, and if we add the current issuance to it, we get the current debt ceiling.
     function debtCeiling() external view returns (uint256) {
         address _guildToken = refs.guildToken; // cached SLOAD
-        uint256 gaugeWeight = GuildToken(_guildToken).getGaugeWeight(address(this));
+        uint256 gaugeWeight = GuildToken(_guildToken).getGaugeWeight(
+            address(this)
+        );
         uint256 gaugeType = GuildToken(_guildToken).gaugeType(address(this));
-        uint256 totalWeight = GuildToken(_guildToken).totalTypeWeight(gaugeType);
-        uint256 creditMinterBuffer = RateLimitedMinter(refs.creditMinter).buffer();
+        uint256 totalWeight = GuildToken(_guildToken).totalTypeWeight(
+            gaugeType
+        );
+        uint256 creditMinterBuffer = RateLimitedMinter(refs.creditMinter)
+            .buffer();
         uint256 _hardCap = params.hardCap; // cached SLOAD
         if (gaugeWeight == 0) {
             return 0; // no gauge vote, 0 debt ceiling
-        }
-        else if (gaugeWeight == totalWeight) {
+        } else if (gaugeWeight == totalWeight) {
             // one gauge, unlimited debt ceiling
             // returns min(hardCap, creditMinterBuffer)
-            return _hardCap < creditMinterBuffer ? _hardCap : creditMinterBuffer;
+            return
+                _hardCap < creditMinterBuffer ? _hardCap : creditMinterBuffer;
         }
         uint256 _issuance = issuance; // cached SLOAD
         uint256 creditTotalSupply = CreditToken(refs.creditToken).totalSupply();
@@ -285,15 +290,18 @@ contract LendingTerm is CoreRef {
             // first-ever CREDIT mint on a non-zero gauge weight term
             // does not check the relative debt ceilings
             // returns min(hardCap, creditMinterBuffer)
-            return _hardCap < creditMinterBuffer ? _hardCap : creditMinterBuffer;
+            return
+                _hardCap < creditMinterBuffer ? _hardCap : creditMinterBuffer;
         }
-        uint256 debtCeilingBefore = creditTotalSupply * gaugeWeight / totalWeight;
+        uint256 debtCeilingBefore = (creditTotalSupply * gaugeWeight) /
+            totalWeight;
         if (_issuance >= debtCeilingBefore) {
             return debtCeilingBefore; // no more borrows allowed
         }
         uint256 remainingDebtCeiling = debtCeilingBefore - _issuance; // always >0
         uint256 otherGaugesWeight = totalWeight - gaugeWeight;
-        uint256 maxBorrow = remainingDebtCeiling * totalWeight / otherGaugesWeight;
+        uint256 maxBorrow = (remainingDebtCeiling * totalWeight) /
+            otherGaugesWeight;
         uint256 _debtCeiling = _issuance + maxBorrow;
         // return min(creditMinterBuffer, hardCap, debtCeiling)
         if (creditMinterBuffer < _debtCeiling) {

--- a/test/unit/loan/LendingTerm.t.sol
+++ b/test/unit/loan/LendingTerm.t.sol
@@ -301,10 +301,22 @@ contract LendingTermUnitTest is Test {
 
     // borrow fail because debt ceiling is reached
     function testBorrowFailDebtCeilingReached() public {
+        // debt ceiling = MAX_UINT if there is only one term
+        assertEq(term.debtCeiling(), type(uint256).max);
+        uint256 _weight = guild.getGaugeWeight(address(term));
+        // if no weight is given to the term, debt ceiling is 0
+        guild.decrementGauge(address(term), _weight);
+        assertEq(term.debtCeiling(), 0);
+        guild.incrementGauge(address(term), _weight);
+
         // add another gauge, equal voting weight for the 2nd gauge
         guild.addGauge(1, address(this));
-        guild.mint(address(this), guild.getGaugeWeight(address(term)));
-        guild.incrementGauge(address(this), uint256(guild.getGaugeWeight(address(term))));
+        guild.mint(address(this), _weight);
+        guild.incrementGauge(address(this), _weight);
+
+        // debt ceiling still MAX_UINT because credit totalSupply is 0
+        // and first-ever mint does not check debt ceiling
+        assertEq(term.debtCeiling(), type(uint256).max);
 
         // prepare
         uint256 borrowAmount = 20_000e18;
@@ -317,9 +329,39 @@ contract LendingTermUnitTest is Test {
         vm.warp(block.timestamp + 10);
         vm.roll(block.number + 1);
 
+        // debt ceiling is 50% of totalSupply (10_000e18), so we
+        // are at 200% utilization
+        assertEq(term.debtCeiling(), 10_000e18);
+
         // second borrow fails because of relative debt ceilings
         vm.expectRevert("LendingTerm: debt ceiling reached");
         term.borrow(borrowAmount, collateralAmount);
+
+        // mint more CREDIT, so that debt ceiling of all terms is increased
+        // new totalSupply is 100_000e18, with 20_000e18 already borrowed on this term.
+        credit.mint(address(this), 80_000e18);
+        // if someone borrows 60_000e18, new totalSupply is 160_000e18, and debt ceiling
+        // of this term is 50% of the new totalSupply, i.e. 80_000e18.
+        assertEq(term.debtCeiling(), 80_000e18);
+
+        // borrow max
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+        collateral.mint(address(this), 30e18);
+        collateral.approve(address(term), 30e18);
+        uint256 maxBorrow = term.debtCeiling() - term.issuance();
+        term.borrow(maxBorrow, 30e18);
+        assertEq(term.issuance(), term.debtCeiling());
+
+        // borrowing even the minimum amount will revert
+        // because debt ceiling is reached
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+        collateral.mint(address(this), 9999e18);
+        collateral.approve(address(term), 9999e18);
+        uint256 _minBorrow = term.MIN_BORROW();
+        vm.expectRevert("LendingTerm: debt ceiling reached");
+        term.borrow(_minBorrow, 30e18);
     }
 
     // borrow fail because hardcap is reached


### PR DESCRIPTION
Add a getter for a LendingTerm's debt ceiling

The getter answers the question "what maximum amount can I borrow on this term right now ?"

Answer is `term.debtCeiling() - term.issuance()`, if current debtCeiling is above issuance, otherwise 0.