### PR TITLE
2023-12 code4rena contest fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Total SLOC: 3739
 
 - **Isolated markets:** by default, each lending asset is risk isolated and has its own set of available lending terms, so bad debt in the ETH market will not affect USDC lenders. It's possible to link the markets by accepting each others' deposit receipts as collateral (gUSDC, gETH, etc).
 - **Auction mechanism:** at first, offer 0% collateral, ask 100% debt. Then, over time, offer a larger % of the collateral and still 100% debt. At 'midpoint', 100% collateral is offered asking for 100% debt, and if nobody has bid, bad debt will be realized. In the second phase, 100% collateral is offered and less and less debt is asked. When we reach the end of the auction (100% collateral offered, 0% debt asked), nobody can bid in the auction anymore, and the loans can be automatically forgiven (marking it as a 100% loss). The first to bid wins the auction, making it a race to arbitrage (onchain MEV or otherwise).
-- **Collateral tokens**: The protocol is expected to handle properly most widely used ERC20 tokens as collateral. The collateral tokens are the least trusted external calls in the system. At launch, we expect to interact with RWA tokens, LSD tokens, and yield-bearing tokens in general, but **no rebasing tokens** and **no fee on transfer**.
+- **Collateral tokens**: The protocol is expected to handle properly most widely used ERC20 tokens as collateral. The collateral tokens are the least trusted external calls in the system. At launch, we expect to interact with RWA tokens, LSD tokens, and yield-bearing tokens in general, but **no rebasing tokens**, **no fee on transfer**, and **no hooks on transfer (à la ERC777)**. These tokens would need a wrapper before being listed in a market, or they could revert arbitrarily and mess up with the internal accounting.
 - **Deployment**: we anticipate to launch on Ethereum mainnet & L2s like Arbitrum.
 - **Trusted actors**: The addresses with `GOVERNOR` and `GUARDIAN` role are trusted. DAO timelock can execute arbitrary calls and impersonate all protocol contracts, as it holds the `GOVERNOR` role. The team multisig has the `GUARDIAN` role, and it is expected to be able to freeze new usage of the protocol, but not prevent users from withdrawing their funds.
 - **Trust minimization**: we expect most roles to be "burnt" (especially `GOVERNOR` and `GUARDIAN`), by deploying automated governance processes that use these privilege but can only make pre-determined calls. Lending term onboarding & offboarding could be done with a simple timelock, but we wrote helper contracts to automate these governance processes, and most governance processes like parameter tuning will be secured like this in the future.
@@ -197,8 +197,8 @@ The set of actions possible in the system are tightly constrained.
 In several cases, a certain quorum of `GUILD` holders can perform a system action or make a parameter change, and another quorum veto it. Each action may have distinct quorums and voting periods or other delays. All of these actions are currently subject to veto except for lending term offboarding.
 
   * adjust the global debt ceiling of any credit token
-  * approve a new `LendingTerm`, which defines collateral ratios, interest rates, etc
-  * remove an existing `LendingTerm`
+  * onboarding a new `LendingTerm`, which defines collateral ratios, interest rates, etc
+  * offboarding an existing `LendingTerm`
   * adjust the split of interest between `GUILD` stakers, the `gUSDC` savings rate, and the surplus buffer
   * adjust the voting duration or quorum threshold for any of the above processes
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "coverage": "forge coverage --fork-url $ETH_RPC_URL --match-path './test/**' --report lcov --report summary",
     "coverage:unit": "forge coverage --match-path './test/unit/**' --report lcov --report summary",
     "coverage:integration": "forge coverage --match-path './test/integration/**' --fork-url $ETH_RPC_URL --report lcov --report summary",
+    "coverage:prune": "lcov --remove ./lcov.info -o ./lcov.info 'test/*'",
     "fork": "anvil --fork-url $ETH_RPC_URL --block-time 10 --chain-id 1337",
     "deploy:local": "ETH_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 forge script scripts/DeployProposal.s.sol:DeployProposal -vvvv --rpc-url http://127.0.0.1:8545 --broadcast",
     "prettier": "npx prettier --check 'src/**/*.sol'",

--- a/protocol-configuration/roles.json
+++ b/protocol-configuration/roles.json
@@ -11,6 +11,11 @@
     "RATE_LIMITED_CREDIT_MINTER",
     "PSM_USDC"
   ],
+  "CREDIT_BURNER": [
+    "PROFIT_MANAGER",
+    "PSM_USDC",
+    "TERM_SDAI_1"
+  ],
   "RATE_LIMITED_CREDIT_MINTER": [
     "TERM_SDAI_1"
   ],

--- a/src/core/Core.sol
+++ b/src/core/Core.sol
@@ -18,6 +18,7 @@ contract Core is AccessControlEnumerable {
         _setRoleAdmin(CoreRoles.GOVERNOR, CoreRoles.GOVERNOR);
         _setRoleAdmin(CoreRoles.GUARDIAN, CoreRoles.GOVERNOR);
         _setRoleAdmin(CoreRoles.CREDIT_MINTER, CoreRoles.GOVERNOR);
+        _setRoleAdmin(CoreRoles.CREDIT_BURNER, CoreRoles.GOVERNOR);
         _setRoleAdmin(CoreRoles.RATE_LIMITED_CREDIT_MINTER, CoreRoles.GOVERNOR);
         _setRoleAdmin(CoreRoles.GUILD_MINTER, CoreRoles.GOVERNOR);
         _setRoleAdmin(CoreRoles.RATE_LIMITED_GUILD_MINTER, CoreRoles.GOVERNOR);

--- a/src/core/CoreRoles.sol
+++ b/src/core/CoreRoles.sol
@@ -19,6 +19,9 @@ library CoreRoles {
     /// @notice can mint CREDIT arbitrarily
     bytes32 internal constant CREDIT_MINTER = keccak256("CREDIT_MINTER_ROLE");
 
+    /// @notice can burn CREDIT tokens
+    bytes32 internal constant CREDIT_BURNER = keccak256("CREDIT_BURNER_ROLE");
+
     /// @notice can mint CREDIT within rate limits & cap
     bytes32 internal constant RATE_LIMITED_CREDIT_MINTER =
         keccak256("RATE_LIMITED_CREDIT_MINTER_ROLE");

--- a/src/governance/GuildVetoGovernor.sol
+++ b/src/governance/GuildVetoGovernor.sol
@@ -254,6 +254,16 @@ contract GuildVetoGovernor is
         revert("GuildVetoGovernor: cannot propose arbitrary actions");
     }
 
+    /// @dev override to prevent cancellation from the proposer
+    function cancel(
+        address[] memory /* targets*/,
+        uint256[] memory /* values*/,
+        bytes[] memory /* calldatas*/,
+        bytes32 /* descriptionHash*/
+    ) public pure override(Governor) returns (uint256) {
+        revert("LendingTermOnboarding: cannot cancel proposals");
+    }
+
     /// @notice Propose a governance action to veto (cancel) a target action ID in the
     /// governor's linked timelock.
     function createVeto(bytes32 timelockId) external returns (uint256) {

--- a/src/governance/GuildVetoGovernor.sol
+++ b/src/governance/GuildVetoGovernor.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.13;
 
 import {Governor, IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";
+import {GovernorSettings} from "@openzeppelin/contracts/governance/extensions/GovernorSettings.sol";
 import {GovernorTimelockControl} from "@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol";
 import {GovernorVotes, IERC165} from "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
 import {GovernorCountingSimple} from "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol";
@@ -22,7 +23,13 @@ import {CoreRoles} from "@src/core/CoreRoles.sol";
 /// After the action has been queued in the linked TimelockController for enough time to be
 /// executed, the veto vote is considered failed and the action cannot be cancelled anymore.
 /// @author eswak
-contract GuildVetoGovernor is CoreRef, Governor, GovernorVotes {
+contract GuildVetoGovernor is
+    CoreRef,
+    Governor,
+    GovernorVotes,
+    GovernorSettings,
+    GovernorCountingSimple
+{
     /// @notice Private storage variable for quorum (the minimum number of votes needed for a vote to pass).
     uint256 private _quorum;
 
@@ -38,6 +45,11 @@ contract GuildVetoGovernor is CoreRef, Governor, GovernorVotes {
         CoreRef(_core)
         Governor("ECG Veto Governor")
         GovernorVotes(IVotes(_token))
+        GovernorSettings(
+            0, // no voting delay
+            2628000, // voting period ~1 year with 1 block every 12s
+            0 // tokens not needed to propose
+        )
     {
         _setQuorum(initialQuorum);
         _updateTimelock(initialTimelock);
@@ -105,77 +117,24 @@ contract GuildVetoGovernor is CoreRef, Governor, GovernorVotes {
     /// Vote counting
     /// ------------------------------------------------------------------------
 
-    /**
-     * @dev Supported vote types. Matches Governor Bravo ordering.
-     */
-    enum VoteType {
-        Against,
-        For,
-        Abstain
-    }
-
-    struct ProposalVote {
-        uint256 againstVotes;
-        uint256 forVotes;
-        uint256 abstainVotes;
-        mapping(address => bool) hasVoted;
-    }
-
-    mapping(uint256 => ProposalVote) private _proposalVotes;
-
-    /**
-     * @dev See {IGovernor-COUNTING_MODE}.
-     */
-    // solhint-disable-next-line func-name-mixedcase
+    // in GovernorCountingSimple: support=bravo&quorum=for,abstain
     function COUNTING_MODE()
         public
         pure
         virtual
-        override
+        override(IGovernor, GovernorCountingSimple)
         returns (string memory)
     {
         return "support=bravo&quorum=against";
     }
 
-    /**
-     * @dev See {IGovernor-hasVoted}.
-     */
-    function hasVoted(
-        uint256 proposalId,
-        address account
-    ) public view virtual override returns (bool) {
-        return _proposalVotes[proposalId].hasVoted[account];
-    }
-
-    /**
-     * @dev Accessor to the internal vote counts.
-     */
-    function proposalVotes(
-        uint256 proposalId
-    )
-        public
-        view
-        virtual
-        returns (uint256 againstVotes, uint256 forVotes, uint256 abstainVotes)
-    {
-        // againstVotes are supporting the execution of Veto
-        againstVotes = _proposalVotes[proposalId].againstVotes;
-        // no forVotes can be cast in the Veto module, keep 0 value
-        forVotes = 0;
-        // no abstainVotes can be cast in the Veto module, keep 0 value
-        abstainVotes = 0;
-    }
-
-    /**
-     * @dev See {Governor-_quorumReached}.
-     */
+    // in GovernorCountingSimple, this returns forVotes + abstainVotes
     function _quorumReached(
         uint256 proposalId
-    ) internal view virtual override returns (bool) {
-        ProposalVote storage proposalvote = _proposalVotes[proposalId];
-
-        return
-            quorum(proposalSnapshot(proposalId)) <= proposalvote.againstVotes;
+    ) internal view virtual override(Governor, GovernorCountingSimple) returns (bool) {
+        (uint256 againstVotes, , ) = proposalVotes(proposalId);
+        uint256 proposalQuorum = quorum(proposalSnapshot(proposalId));
+        return proposalQuorum <= againstVotes;
     }
 
     /**
@@ -183,53 +142,41 @@ contract GuildVetoGovernor is CoreRef, Governor, GovernorVotes {
      * between 'for' and 'against' votes, since people cannot vote 'for'. For a veto to be considered successful,
      * it only needs to reach quorum.
      */
+    // in GovernorCountingSimple, this returns forVotes > againstVotes
     function _voteSucceeded(
         uint256 /* proposalId*/
-    ) internal pure virtual override returns (bool) {
+    ) internal pure virtual override(Governor, GovernorCountingSimple) returns (bool) {
         return true;
     }
 
     /**
      * @dev See {Governor-_countVote}. In this module, the support follows the `VoteType` enum (from Governor Bravo).
      */
+    /// @dev in Veto governor, only allow 'against' votes.
     function _countVote(
         uint256 proposalId,
         address account,
         uint8 support,
         uint256 weight,
-        bytes memory // params
-    ) internal virtual override {
-        ProposalVote storage proposalvote = _proposalVotes[proposalId];
+        bytes memory params
+    ) internal virtual override(Governor, GovernorCountingSimple) {
+        require(support == uint8(VoteType.Against), "GuildVetoGovernor: can only vote against in veto proposals");
+        super._countVote(proposalId, account, support, weight, params);
+    }
 
-        require(
-            !proposalvote.hasVoted[account],
-            "GuildVetoGovernor: vote already cast"
-        );
-        proposalvote.hasVoted[account] = true;
-
-        if (support == uint8(VoteType.Against)) {
-            proposalvote.againstVotes += weight;
-        } else {
-            revert("GuildVetoGovernor: can only vote against in veto proposals");
-        }
+    // inheritance reconciliation
+    function proposalThreshold()
+        public
+        view
+        override(Governor, GovernorSettings)
+        returns (uint256)
+    {
+        return super.proposalThreshold();
     }
 
     /// ------------------------------------------------------------------------
     /// Public functions override
     /// ------------------------------------------------------------------------
-
-    /// @dev no voting delay between veto proposal and veto voting period.
-    function votingDelay() public pure override returns (uint256) {
-        return 0;
-    }
-
-    /// @dev voting period is unused, it is a duration in blocks for the vote
-    /// but the timestamp of the action in the timelock is used to know if the
-    /// vote period is over (after action is ready in the timelock, the veto
-    /// vote failed).
-    function votingPeriod() public pure override returns (uint256) {
-        return 2425847; // ~1 year with 1 block every 13s
-    }
 
     /// @notice State of a given proposal
     /// The state can be one of:
@@ -282,10 +229,7 @@ contract GuildVetoGovernor is CoreRef, Governor, GovernorVotes {
         // proposal still in waiting period in the timelock
         if (timelockOperationTimestamp > block.timestamp) {
             // ready to veto
-            // no need for "&& _voteSucceeded(proposalId)" in condition because
-            // veto votes are always succeeded (there is no tallying for 'for'
-            // votes against 'against' votes), the only condition is the quorum.
-            if (_quorumReached(proposalId)) {
+            if (_quorumReached(proposalId) && _voteSucceeded(proposalId)) {
                 return ProposalState.Succeeded;
             }
             // need more votes to veto

--- a/src/governance/GuildVetoGovernor.sol
+++ b/src/governance/GuildVetoGovernor.sol
@@ -131,7 +131,13 @@ contract GuildVetoGovernor is
     // in GovernorCountingSimple, this returns forVotes + abstainVotes
     function _quorumReached(
         uint256 proposalId
-    ) internal view virtual override(Governor, GovernorCountingSimple) returns (bool) {
+    )
+        internal
+        view
+        virtual
+        override(Governor, GovernorCountingSimple)
+        returns (bool)
+    {
         (uint256 againstVotes, , ) = proposalVotes(proposalId);
         uint256 proposalQuorum = quorum(proposalSnapshot(proposalId));
         return proposalQuorum <= againstVotes;
@@ -145,7 +151,13 @@ contract GuildVetoGovernor is
     // in GovernorCountingSimple, this returns forVotes > againstVotes
     function _voteSucceeded(
         uint256 /* proposalId*/
-    ) internal pure virtual override(Governor, GovernorCountingSimple) returns (bool) {
+    )
+        internal
+        pure
+        virtual
+        override(Governor, GovernorCountingSimple)
+        returns (bool)
+    {
         return true;
     }
 
@@ -160,7 +172,10 @@ contract GuildVetoGovernor is
         uint256 weight,
         bytes memory params
     ) internal virtual override(Governor, GovernorCountingSimple) {
-        require(support == uint8(VoteType.Against), "GuildVetoGovernor: can only vote against in veto proposals");
+        require(
+            support == uint8(VoteType.Against),
+            "GuildVetoGovernor: can only vote against in veto proposals"
+        );
         super._countVote(proposalId, account, support, weight, params);
     }
 

--- a/src/governance/LendingTermOffboarding.sol
+++ b/src/governance/LendingTermOffboarding.sol
@@ -33,7 +33,7 @@ contract LendingTermOffboarding is CoreRef {
     /// @notice maximum age of polls for them to be considered valid.
     /// This offboarding mechanism is meant to be used in a reactive fashion, and
     /// polls should not stay open for a long time.
-    uint256 public constant POLL_DURATION_BLOCKS = 46523; // ~7 days @ 13s/block
+    uint256 public constant POLL_DURATION_BLOCKS = 50400; // ~7 days @ 12s/block
 
     /// @notice quorum for offboarding a lending term
     uint256 public quorum;
@@ -58,7 +58,8 @@ contract LendingTermOffboarding is CoreRef {
     mapping(address => uint256) public lastPollBlock;
 
     /// @notice mapping of terms that can be offboarded.
-    mapping(address => bool) public canOffboard;
+    mapping(address => OffboardStatus) public canOffboard;
+    enum OffboardStatus {UNSET, CAN_OFFBOARD, CAN_CLEANUP}
 
     /// @notice number of offboardings in progress.
     uint256 public nOffboardingsInProgress;
@@ -100,6 +101,8 @@ contract LendingTermOffboarding is CoreRef {
             GuildToken(guildToken).isGauge(term),
             "LendingTermOffboarding: not an active term"
         );
+        // Check that another offboarding is not in progress
+        require(canOffboard[term] == OffboardStatus.UNSET, "LendingTermOffboarding: offboard in progress");
 
         polls[block.number][term] = 1; // voting power
         lastPollBlock[term] = block.number;
@@ -136,7 +139,7 @@ contract LendingTermOffboarding is CoreRef {
         userPollVotes[msg.sender][snapshotBlock][term] = userWeight;
         polls[snapshotBlock][term] = _weight + userWeight;
         if (_weight + userWeight >= quorum) {
-            canOffboard[term] = true;
+            canOffboard[term] = OffboardStatus.CAN_OFFBOARD;
         }
         emit OffboardSupport(
             block.timestamp,
@@ -151,7 +154,9 @@ contract LendingTermOffboarding is CoreRef {
     /// This will prevent new loans from being open, and will prevent GUILD holders to vote for the term.
     /// @param term LendingTerm to offboard from the system.
     function offboard(address term) external whenNotPaused {
-        require(canOffboard[term], "LendingTermOffboarding: quorum not met");
+        require(canOffboard[term] == OffboardStatus.CAN_OFFBOARD, "LendingTermOffboarding: cannot offboard");
+        canOffboard[term] = OffboardStatus.CAN_CLEANUP;
+        lastPollBlock[term] = 1; // not 0 to reduce gas cost of next offboard
 
         // update protocol config
         // this will revert if the term has already been offboarded
@@ -173,15 +178,18 @@ contract LendingTermOffboarding is CoreRef {
     /// This is only callable after a term has been offboarded and all its loans have been closed.
     /// @param term LendingTerm to cleanup.
     function cleanup(address term) external whenNotPaused {
-        require(canOffboard[term], "LendingTermOffboarding: quorum not met");
         require(
             LendingTerm(term).issuance() == 0,
             "LendingTermOffboarding: not all loans closed"
         );
         require(
-            GuildToken(guildToken).isDeprecatedGauge(term),
+            GuildToken(guildToken).isDeprecatedGauge(term) &&
+                core().hasRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, term) &&
+                core().hasRole(CoreRoles.GAUGE_PNL_NOTIFIER, term),
             "LendingTermOffboarding: re-onboarded"
         );
+        require(canOffboard[term] == OffboardStatus.CAN_CLEANUP, "LendingTermOffboarding: cannot cleanup");
+        canOffboard[term] = OffboardStatus.UNSET;
 
         // update protocol config
         core().revokeRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, term);
@@ -194,7 +202,33 @@ contract LendingTermOffboarding is CoreRef {
             SimplePSM(psm).setRedemptionsPaused(false);
         }
 
-        canOffboard[term] = false;
         emit Cleanup(block.timestamp, term);
+    }
+
+    /// @notice Can reset an offboarding process if the term has been re-onboarded
+    /// The offboard flow looks like the following :
+    /// - 1) proposeOffboard()
+    /// - 2) supportOffboard()
+    /// - 3) offboard()
+    /// - 3a) if not re-onboarded before cleanup, cleanup()
+    /// - 3b) if re-onboarded before cleanup, resetOffboarding()
+    /// @param term LendingTerm to reset offboarding for.
+    function resetOffboarding(address term) external whenNotPaused {
+        require(canOffboard[term] != OffboardStatus.UNSET, "LendingTermOffboarding: cannot reset");
+        require(
+            GuildToken(guildToken).isGauge(term) &&
+                core().hasRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, term) &&
+                core().hasRole(CoreRoles.GAUGE_PNL_NOTIFIER, term),
+            "LendingTermOffboarding: not re-onboarded"
+        );
+
+        // unpause psm redemptions
+        if (
+            --nOffboardingsInProgress == 0 && SimplePSM(psm).redemptionsPaused()
+        ) {
+            SimplePSM(psm).setRedemptionsPaused(false);
+        }
+
+        canOffboard[term] = OffboardStatus.UNSET;
     }
 }

--- a/src/governance/LendingTermOffboarding.sol
+++ b/src/governance/LendingTermOffboarding.sol
@@ -194,6 +194,7 @@ contract LendingTermOffboarding is CoreRef {
         );
         require(
             GuildToken(guildToken).isDeprecatedGauge(term) &&
+                core().hasRole(CoreRoles.CREDIT_BURNER, term) &&
                 core().hasRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, term) &&
                 core().hasRole(CoreRoles.GAUGE_PNL_NOTIFIER, term),
             "LendingTermOffboarding: re-onboarded"
@@ -205,6 +206,7 @@ contract LendingTermOffboarding is CoreRef {
         canOffboard[term] = OffboardStatus.UNSET;
 
         // update protocol config
+        core().revokeRole(CoreRoles.CREDIT_BURNER, term);
         core().revokeRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, term);
         core().revokeRole(CoreRoles.GAUGE_PNL_NOTIFIER, term);
 
@@ -233,6 +235,7 @@ contract LendingTermOffboarding is CoreRef {
         );
         require(
             GuildToken(guildToken).isGauge(term) &&
+                core().hasRole(CoreRoles.CREDIT_BURNER, term) &&
                 core().hasRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, term) &&
                 core().hasRole(CoreRoles.GAUGE_PNL_NOTIFIER, term),
             "LendingTermOffboarding: not re-onboarded"

--- a/src/governance/LendingTermOffboarding.sol
+++ b/src/governance/LendingTermOffboarding.sol
@@ -59,7 +59,11 @@ contract LendingTermOffboarding is CoreRef {
 
     /// @notice mapping of terms that can be offboarded.
     mapping(address => OffboardStatus) public canOffboard;
-    enum OffboardStatus {UNSET, CAN_OFFBOARD, CAN_CLEANUP}
+    enum OffboardStatus {
+        UNSET,
+        CAN_OFFBOARD,
+        CAN_CLEANUP
+    }
 
     /// @notice number of offboardings in progress.
     uint256 public nOffboardingsInProgress;
@@ -102,7 +106,10 @@ contract LendingTermOffboarding is CoreRef {
             "LendingTermOffboarding: not an active term"
         );
         // Check that another offboarding is not in progress
-        require(canOffboard[term] == OffboardStatus.UNSET, "LendingTermOffboarding: offboard in progress");
+        require(
+            canOffboard[term] == OffboardStatus.UNSET,
+            "LendingTermOffboarding: offboard in progress"
+        );
 
         polls[block.number][term] = 1; // voting power
         lastPollBlock[term] = block.number;
@@ -154,7 +161,10 @@ contract LendingTermOffboarding is CoreRef {
     /// This will prevent new loans from being open, and will prevent GUILD holders to vote for the term.
     /// @param term LendingTerm to offboard from the system.
     function offboard(address term) external whenNotPaused {
-        require(canOffboard[term] == OffboardStatus.CAN_OFFBOARD, "LendingTermOffboarding: cannot offboard");
+        require(
+            canOffboard[term] == OffboardStatus.CAN_OFFBOARD,
+            "LendingTermOffboarding: cannot offboard"
+        );
         canOffboard[term] = OffboardStatus.CAN_CLEANUP;
         lastPollBlock[term] = 1; // not 0 to reduce gas cost of next offboard
 
@@ -188,7 +198,10 @@ contract LendingTermOffboarding is CoreRef {
                 core().hasRole(CoreRoles.GAUGE_PNL_NOTIFIER, term),
             "LendingTermOffboarding: re-onboarded"
         );
-        require(canOffboard[term] == OffboardStatus.CAN_CLEANUP, "LendingTermOffboarding: cannot cleanup");
+        require(
+            canOffboard[term] == OffboardStatus.CAN_CLEANUP,
+            "LendingTermOffboarding: cannot cleanup"
+        );
         canOffboard[term] = OffboardStatus.UNSET;
 
         // update protocol config
@@ -214,7 +227,10 @@ contract LendingTermOffboarding is CoreRef {
     /// - 3b) if re-onboarded before cleanup, resetOffboarding()
     /// @param term LendingTerm to reset offboarding for.
     function resetOffboarding(address term) external whenNotPaused {
-        require(canOffboard[term] != OffboardStatus.UNSET, "LendingTermOffboarding: cannot reset");
+        require(
+            canOffboard[term] != OffboardStatus.UNSET,
+            "LendingTermOffboarding: cannot reset"
+        );
         require(
             GuildToken(guildToken).isGauge(term) &&
                 core().hasRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, term) &&

--- a/src/governance/LendingTermOffboarding.sol
+++ b/src/governance/LendingTermOffboarding.sol
@@ -173,7 +173,8 @@ contract LendingTermOffboarding is CoreRef {
         // through another mean.
         GuildToken(guildToken).removeGauge(term);
 
-        // pause psm redemptions
+        // if there are no other offboardings in progress, this is the
+        // first offboarding to start, so we pause psm redemptions
         if (
             nOffboardingsInProgress++ == 0 &&
             !SimplePSM(psm).redemptionsPaused()
@@ -210,7 +211,8 @@ contract LendingTermOffboarding is CoreRef {
         core().revokeRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, term);
         core().revokeRole(CoreRoles.GAUGE_PNL_NOTIFIER, term);
 
-        // unpause psm redemptions
+        // if there are no other offboardings in progress, this is the
+        // last offboarding to end, so we unpause psm redemptions
         if (
             --nOffboardingsInProgress == 0 && SimplePSM(psm).redemptionsPaused()
         ) {
@@ -241,7 +243,8 @@ contract LendingTermOffboarding is CoreRef {
             "LendingTermOffboarding: not re-onboarded"
         );
 
-        // unpause psm redemptions
+        // if there are no other offboardings in progress, this is the
+        // last offboarding to end, so we unpause psm redemptions
         if (
             --nOffboardingsInProgress == 0 && SimplePSM(psm).redemptionsPaused()
         ) {

--- a/src/governance/LendingTermOnboarding.sol
+++ b/src/governance/LendingTermOnboarding.sol
@@ -276,9 +276,9 @@ contract LendingTermOnboarding is GuildGovernor {
             string memory description
         )
     {
-        targets = new address[](3);
-        values = new uint256[](3);
-        calldatas = new bytes[](3);
+        targets = new address[](4);
+        values = new uint256[](4);
+        calldatas = new bytes[](4);
         description = string.concat(
             "[",
             Strings.toString(block.number),
@@ -295,18 +295,26 @@ contract LendingTermOnboarding is GuildGovernor {
             term
         );
 
-        // 2nd call: core.grantRole(term, RATE_LIMITED_CREDIT_MINTER)
+        // 2nd call: core.grantRole(term, CREDIT_BURNER)
         address _core = address(core());
         targets[1] = _core;
         calldatas[1] = abi.encodeWithSelector(
+            AccessControl.grantRole.selector,
+            CoreRoles.CREDIT_BURNER,
+            term
+        );
+
+        // 3rd call: core.grantRole(term, RATE_LIMITED_CREDIT_MINTER)
+        targets[2] = _core;
+        calldatas[2] = abi.encodeWithSelector(
             AccessControl.grantRole.selector,
             CoreRoles.RATE_LIMITED_CREDIT_MINTER,
             term
         );
 
-        // 3rd call: core.grantRole(term, GAUGE_PNL_NOTIFIER)
-        targets[2] = _core;
-        calldatas[2] = abi.encodeWithSelector(
+        // 4th call: core.grantRole(term, GAUGE_PNL_NOTIFIER)
+        targets[3] = _core;
+        calldatas[3] = abi.encodeWithSelector(
             AccessControl.grantRole.selector,
             CoreRoles.GAUGE_PNL_NOTIFIER,
             term

--- a/src/governance/LendingTermOnboarding.sol
+++ b/src/governance/LendingTermOnboarding.sol
@@ -177,6 +177,14 @@ contract LendingTermOnboarding is GuildGovernor {
             "LendingTermOnboarding: invalid hardCap"
         );
 
+        // if one of the periodic payment parameter is used, both must be used
+        if (params.minPartialRepayPercent != 0 || params.maxDelayBetweenPartialRepay != 0) {
+            require(
+                params.minPartialRepayPercent != 0 && params.maxDelayBetweenPartialRepay != 0,
+                "LendingTermOnboarding: invalid periodic payment params"
+            );
+        }
+
         // check that references for this market has been set
         MarketReferences storage references = marketReferences[gaugeType];
         require(references.profitManager != address(0), "LendingTermOnboarding: unknown market");

--- a/src/governance/LendingTermOnboarding.sol
+++ b/src/governance/LendingTermOnboarding.sol
@@ -216,6 +216,16 @@ contract LendingTermOnboarding is GuildGovernor {
         revert("LendingTermOnboarding: cannot propose arbitrary actions");
     }
 
+    /// @dev override to prevent cancellation from the proposer
+    function cancel(
+        address[] memory /* targets*/,
+        uint256[] memory /* values*/,
+        bytes[] memory /* calldatas*/,
+        bytes32 /* descriptionHash*/
+    ) public pure override(IGovernor, Governor) returns (uint256) {
+        revert("LendingTermOnboarding: cannot cancel proposals");
+    }
+
     /// @notice Propose the onboarding of a term
     function proposeOnboard(
         address term

--- a/src/governance/LendingTermOnboarding.sol
+++ b/src/governance/LendingTermOnboarding.sol
@@ -115,11 +115,7 @@ contract LendingTermOnboarding is GuildGovernor {
         bool allowed
     ) external onlyCoreRole(CoreRoles.GOVERNOR) {
         auctionHouses[auctionHouse] = allowed;
-        emit AuctionHouseAllowChanged(
-            block.timestamp,
-            auctionHouse,
-            allowed
-        );
+        emit AuctionHouseAllowChanged(block.timestamp, auctionHouse, allowed);
     }
 
     /// @notice Create a new LendingTerm and initialize it.
@@ -178,16 +174,23 @@ contract LendingTermOnboarding is GuildGovernor {
         );
 
         // if one of the periodic payment parameter is used, both must be used
-        if (params.minPartialRepayPercent != 0 || params.maxDelayBetweenPartialRepay != 0) {
+        if (
+            params.minPartialRepayPercent != 0 ||
+            params.maxDelayBetweenPartialRepay != 0
+        ) {
             require(
-                params.minPartialRepayPercent != 0 && params.maxDelayBetweenPartialRepay != 0,
+                params.minPartialRepayPercent != 0 &&
+                    params.maxDelayBetweenPartialRepay != 0,
                 "LendingTermOnboarding: invalid periodic payment params"
             );
         }
 
         // check that references for this market has been set
         MarketReferences storage references = marketReferences[gaugeType];
-        require(references.profitManager != address(0), "LendingTermOnboarding: unknown market");
+        require(
+            references.profitManager != address(0),
+            "LendingTermOnboarding: unknown market"
+        );
 
         address term = Clones.clone(implementation);
         LendingTerm(term).initialize(

--- a/src/governance/LendingTermOnboarding.sol
+++ b/src/governance/LendingTermOnboarding.sol
@@ -32,21 +32,19 @@ contract LendingTermOnboarding is GuildGovernor {
     mapping(address => bool) public auctionHouses;
     /// @notice immutable reference to the guild token
     address public immutable guildToken;
-    /// @notice immutable reference to the gauge type to use for the terms onboarded
-    uint256 public immutable gaugeType;
 
-    /// @notice timestamp of creation of a term
-    /// (used to check that a term has been created by this factory)
-    mapping(address => uint256) public created;
+    /// @notice gaugeType of created terms
+    /// note that gaugeType 0 is not valid, so this mapping can be used
+    /// to check that a term has been created by this factory.
+    mapping(address => uint256) public gaugeTypes;
 
-    /// @notice reference to profitManager to set in created lending terms
-    address public immutable profitManager;
-    /// @notice reference to auctionHouse to set in created lending terms
-    address public immutable auctionHouse;
-    /// @notice reference to creditMinter to set in created lending terms
-    address public immutable creditMinter;
-    /// @notice reference to creditToken to set in created lending terms
-    address public immutable creditToken;
+    /// @notice mapping of references per market (key = gaugeType = market id)
+    mapping(uint256 => MarketReferences) public marketReferences;
+    struct MarketReferences {
+        address profitManager;
+        address creditMinter;
+        address creditToken;
+    }
 
     /// @notice emitted when a lending term implementation's "allowed" status changes
     event ImplementationAllowChanged(
@@ -69,10 +67,9 @@ contract LendingTermOnboarding is GuildGovernor {
     );
 
     constructor(
-        LendingTerm.LendingTermReferences memory _lendingTermReferences,
-        uint256 _gaugeType,
         address _core,
         address _timelock,
+        address _guildToken,
         uint256 initialVotingDelay,
         uint256 initialVotingPeriod,
         uint256 initialProposalThreshold,
@@ -81,19 +78,22 @@ contract LendingTermOnboarding is GuildGovernor {
         GuildGovernor(
             _core,
             _timelock,
-            _lendingTermReferences.guildToken,
+            _guildToken,
             initialVotingDelay,
             initialVotingPeriod,
             initialProposalThreshold,
             initialQuorum
         )
     {
-        guildToken = _lendingTermReferences.guildToken;
-        gaugeType = _gaugeType;
-        profitManager = _lendingTermReferences.profitManager;
-        auctionHouse = _lendingTermReferences.auctionHouse;
-        creditMinter = _lendingTermReferences.creditMinter;
-        creditToken = _lendingTermReferences.creditToken;
+        guildToken = _guildToken;
+    }
+
+    /// @notice set market references for a given market id
+    function setMarketReferences(
+        uint256 gaugeType,
+        MarketReferences calldata references
+    ) external onlyCoreRole(CoreRoles.GOVERNOR) {
+        marketReferences[gaugeType] = references;
     }
 
     /// @notice Allow or disallow a given implemenation
@@ -124,6 +124,7 @@ contract LendingTermOnboarding is GuildGovernor {
 
     /// @notice Create a new LendingTerm and initialize it.
     function createTerm(
+        uint256 gaugeType,
         address implementation,
         address auctionHouse,
         LendingTerm.LendingTermParams calldata params
@@ -176,19 +177,23 @@ contract LendingTermOnboarding is GuildGovernor {
             "LendingTermOnboarding: invalid hardCap"
         );
 
+        // check that references for this market has been set
+        MarketReferences storage references = marketReferences[gaugeType];
+        require(references.profitManager != address(0), "LendingTermOnboarding: unknown market");
+
         address term = Clones.clone(implementation);
         LendingTerm(term).initialize(
             address(core()),
             LendingTerm.LendingTermReferences({
-                profitManager: profitManager,
+                profitManager: references.profitManager,
                 guildToken: guildToken,
                 auctionHouse: auctionHouse,
-                creditMinter: creditMinter,
-                creditToken: creditToken
+                creditMinter: references.creditMinter,
+                creditToken: references.creditToken
             }),
             params
         );
-        created[term] = block.timestamp;
+        gaugeTypes[term] = gaugeType;
         emit TermCreated(block.timestamp, implementation, term, params);
         return term;
     }
@@ -208,7 +213,7 @@ contract LendingTermOnboarding is GuildGovernor {
         address term
     ) external whenNotPaused returns (uint256 proposalId) {
         // Check that the term has been created by this factory
-        require(created[term] != 0, "LendingTermOnboarding: invalid term");
+        require(gaugeTypes[term] != 0, "LendingTermOnboarding: invalid term");
 
         // Check that the term was not subject to an onboard vote recently
         require(
@@ -265,7 +270,7 @@ contract LendingTermOnboarding is GuildGovernor {
         targets[0] = guildToken;
         calldatas[0] = abi.encodeWithSelector(
             GuildToken.addGauge.selector,
-            gaugeType,
+            gaugeTypes[term],
             term
         );
 

--- a/src/governance/ProfitManager.sol
+++ b/src/governance/ProfitManager.sol
@@ -170,9 +170,7 @@ contract ProfitManager is CoreRef {
         address _credit,
         address _guild
     ) external onlyCoreRole(CoreRoles.GOVERNOR) {
-        assert(
-            credit == address(0) && guild == address(0)
-        );
+        assert(credit == address(0) && guild == address(0));
         credit = _credit;
         guild = _guild;
     }

--- a/src/governance/ProfitManager.sol
+++ b/src/governance/ProfitManager.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.13;
 
 import {CoreRef} from "@src/core/CoreRef.sol";
 import {CoreRoles} from "@src/core/CoreRoles.sol";
-import {SimplePSM} from "@src/loan/SimplePSM.sol";
 import {GuildToken} from "@src/tokens/GuildToken.sol";
 import {CreditToken} from "@src/tokens/CreditToken.sol";
 
@@ -33,9 +32,6 @@ contract ProfitManager is CoreRef {
 
     /// @notice reference to CREDIT token.
     address public credit;
-
-    /// @notice reference to CREDIT token PSM.
-    address public psm;
 
     /// @notice profit index of a given gauge
     mapping(address => uint256) public gaugeProfitIndex;
@@ -172,15 +168,13 @@ contract ProfitManager is CoreRef {
     /// @notice initialize references to GUILD & CREDIT tokens.
     function initializeReferences(
         address _credit,
-        address _guild,
-        address _psm
+        address _guild
     ) external onlyCoreRole(CoreRoles.GOVERNOR) {
         assert(
-            credit == address(0) && guild == address(0) && psm == address(0)
+            credit == address(0) && guild == address(0)
         );
         credit = _credit;
         guild = _guild;
-        psm = _psm;
     }
 
     /// @notice set the minimum borrow amount

--- a/src/governance/ProfitManager.sol
+++ b/src/governance/ProfitManager.sol
@@ -354,11 +354,6 @@ contract ProfitManager is CoreRef {
             uint256 amountForOther = (uint256(amount) *
                 uint256(_profitSharingConfig.otherSplit)) / 1e9;
 
-            uint256 amountForCredit = uint256(amount) -
-                amountForSurplusBuffer -
-                amountForGuild -
-                amountForOther;
-
             // distribute to surplus buffer
             if (amountForSurplusBuffer != 0) {
                 surplusBuffer = _surplusBuffer + amountForSurplusBuffer;
@@ -377,8 +372,14 @@ contract ProfitManager is CoreRef {
             }
 
             // distribute to lenders
-            if (amountForCredit != 0) {
-                CreditToken(_credit).distribute(amountForCredit);
+            {
+                uint256 amountForCredit = uint256(amount) -
+                    amountForSurplusBuffer -
+                    amountForGuild -
+                    amountForOther;
+                if (amountForCredit != 0) {
+                    CreditToken(_credit).distribute(amountForCredit);
+                }
             }
 
             // distribute to the guild

--- a/src/governance/ProfitManager.sol
+++ b/src/governance/ProfitManager.sol
@@ -330,7 +330,7 @@ contract ProfitManager is CoreRef {
                 emit SurplusBufferUpdate(block.timestamp, 0);
 
                 // update the CREDIT multiplier
-                uint256 creditTotalSupply = CreditToken(_credit).totalSupply();
+                uint256 creditTotalSupply = CreditToken(_credit).targetTotalSupply();
                 uint256 newCreditMultiplier = (creditMultiplier *
                     (creditTotalSupply - loss)) / creditTotalSupply;
                 creditMultiplier = newCreditMultiplier;

--- a/src/governance/ProfitManager.sol
+++ b/src/governance/ProfitManager.sol
@@ -182,6 +182,7 @@ contract ProfitManager is CoreRef {
     function setGaugeWeightTolerance(
         uint256 newValue
     ) external onlyCoreRole(CoreRoles.GOVERNOR) {
+        require(newValue >= 1e18, "ProfitManager: invalid tolerance");
         gaugeWeightTolerance = newValue;
         emit GaugeWeightToleranceUpdate(block.timestamp, newValue);
     }

--- a/src/governance/ProfitManager.sol
+++ b/src/governance/ProfitManager.sol
@@ -245,9 +245,9 @@ contract ProfitManager is CoreRef {
 
     /// @notice donate to surplus buffer
     function donateToSurplusBuffer(uint256 amount) external {
-        CreditToken(credit).transferFrom(msg.sender, address(this), amount);
         uint256 newSurplusBuffer = surplusBuffer + amount;
         surplusBuffer = newSurplusBuffer;
+        CreditToken(credit).transferFrom(msg.sender, address(this), amount);
         emit SurplusBufferUpdate(block.timestamp, newSurplusBuffer);
     }
 

--- a/src/governance/ProfitManager.sol
+++ b/src/governance/ProfitManager.sol
@@ -322,8 +322,12 @@ contract ProfitManager is CoreRef {
 
         // check the maximum total issuance if the issuance is changing
         if (issuanceDelta > 0) {
-            uint256 __maxTotalIssuance = (_maxTotalIssuance * 1e18) / creditMultiplier;
-            require(totalIssuance <= __maxTotalIssuance, "ProfitManager: global debt ceiling reached");
+            uint256 __maxTotalIssuance = (_maxTotalIssuance * 1e18) /
+                creditMultiplier;
+            require(
+                totalIssuance <= __maxTotalIssuance,
+                "ProfitManager: global debt ceiling reached"
+            );
         }
 
         // handling loss
@@ -357,7 +361,8 @@ contract ProfitManager is CoreRef {
                 emit SurplusBufferUpdate(block.timestamp, 0);
 
                 // update the CREDIT multiplier
-                uint256 creditTotalSupply = CreditToken(_credit).targetTotalSupply();
+                uint256 creditTotalSupply = CreditToken(_credit)
+                    .targetTotalSupply();
                 uint256 newCreditMultiplier = (creditMultiplier *
                     (creditTotalSupply - loss)) / creditTotalSupply;
                 creditMultiplier = newCreditMultiplier;

--- a/src/loan/AuctionHouse.sol
+++ b/src/loan/AuctionHouse.sol
@@ -71,8 +71,7 @@ contract AuctionHouse is CoreRef {
     /// @notice start the auction of the collateral of a loan, to be exchanged for CREDIT,
     /// in order to pay the debt of a loan.
     /// @param loanId the ID of the loan which collateral is auctioned
-    /// @param callDebt the amount of CREDIT debt to recover from the collateral auction
-    function startAuction(bytes32 loanId, uint256 callDebt) external {
+    function startAuction(bytes32 loanId) external {
         // check that caller is a lending term that still has PnL reporting role
         require(
             core().hasRole(CoreRoles.GAUGE_PNL_NOTIFIER, msg.sender),
@@ -98,7 +97,7 @@ contract AuctionHouse is CoreRef {
             endTime: 0,
             lendingTerm: msg.sender,
             collateralAmount: loan.collateralAmount,
-            callDebt: callDebt
+            callDebt: loan.callDebt
         });
         nAuctionsInProgress++;
 
@@ -108,7 +107,7 @@ contract AuctionHouse is CoreRef {
             loanId,
             LendingTerm(msg.sender).collateralToken(),
             loan.collateralAmount,
-            callDebt
+            loan.callDebt
         );
     }
 
@@ -152,7 +151,8 @@ contract AuctionHouse is CoreRef {
             creditAsked = _callDebt - (_callDebt * elapsed) / PHASE_2_DURATION;
         }
         // second phase fully elapsed, anyone can receive the full collateral and give 0 CREDIT
-        // in practice, somebody should have taken the arb before we reach this condition.
+        // in practice, somebody should have taken the arb before we reach this condition, and
+        // there are conditions in bid() & forgive() to prevent this from happening.
         else {
             // receive the full collateral
             collateralReceived = auctions[loanId].collateralAmount;

--- a/src/loan/AuctionHouse.sol
+++ b/src/loan/AuctionHouse.sol
@@ -106,7 +106,9 @@ contract AuctionHouse is CoreRef {
             lendingTerm: msg.sender,
             collateralAmount: loan.collateralAmount,
             callDebt: loan.callDebt,
-            callCreditMultiplier: ProfitManager(LendingTerm(msg.sender).profitManager()).creditMultiplier()
+            callCreditMultiplier: ProfitManager(
+                LendingTerm(msg.sender).profitManager()
+            ).creditMultiplier()
         });
         nAuctionsInProgress++;
 
@@ -146,9 +148,14 @@ contract AuctionHouse is CoreRef {
             // compute amount of collateral received
             uint256 elapsed = block.timestamp - _startTime; // [0, midPoint[
             uint256 _collateralAmount = auctions[loanId].collateralAmount; // SLOAD
-            uint256 minCollateralReceived = startCollateralOffered * _collateralAmount / 1e18;
-            uint256 remainingCollateral = _collateralAmount - minCollateralReceived;
-            collateralReceived = minCollateralReceived + (remainingCollateral * elapsed) / midPoint;
+            uint256 minCollateralReceived = (startCollateralOffered *
+                _collateralAmount) / 1e18;
+            uint256 remainingCollateral = _collateralAmount -
+                minCollateralReceived;
+            collateralReceived =
+                minCollateralReceived +
+                (remainingCollateral * elapsed) /
+                midPoint;
         }
         // second phase of the auction, where less and less CREDIT is asked
         else if (block.timestamp < _startTime + auctionDuration) {
@@ -171,8 +178,12 @@ contract AuctionHouse is CoreRef {
         }
 
         // apply eventual creditMultiplier updates
-        uint256 creditMultiplier = ProfitManager(LendingTerm(auctions[loanId].lendingTerm).profitManager()).creditMultiplier();
-        creditAsked = creditAsked * auctions[loanId].callCreditMultiplier / creditMultiplier;
+        uint256 creditMultiplier = ProfitManager(
+            LendingTerm(auctions[loanId].lendingTerm).profitManager()
+        ).creditMultiplier();
+        creditAsked =
+            (creditAsked * auctions[loanId].callCreditMultiplier) /
+            creditMultiplier;
     }
 
     /// @notice bid for an active auction

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -725,6 +725,9 @@ contract LendingTerm is CoreRef {
         // check that the loan exists
         require(loan.borrowTime != 0, "LendingTerm: loan not found");
 
+        // check that the loan is not already called
+        require(loan.callTime == 0, "LendingTerm: loan called");
+
         // check that the loan is not already closed
         require(loan.closeTime == 0, "LendingTerm: loan closed");
 

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -64,7 +64,8 @@ contract LendingTerm is CoreRef {
         bytes32 s;
     }
 
-    /// @notice reference number of seconds in 1 year
+    /// @notice Reference number of seconds per periods in which the interestRate is expressed.
+    /// This is equal to 365.25 days.
     uint256 public constant YEAR = 31557600;
 
     /// @notice timestamp of last partial repayment for a given loanId.

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -217,7 +217,10 @@ contract LendingTerm is CoreRef {
 
     /// @notice outstanding borrowed amount of a loan, including interests,
     /// given a creditMultiplier
-    function _getLoanDebt(bytes32 loanId, uint256 creditMultiplier) internal view returns (uint256) {
+    function _getLoanDebt(
+        bytes32 loanId,
+        uint256 creditMultiplier
+    ) internal view returns (uint256) {
         Loan storage loan = loans[loanId];
         uint256 borrowTime = loan.borrowTime;
 
@@ -251,16 +254,22 @@ contract LendingTerm is CoreRef {
     }
 
     /// @notice maximum debt for a given amount of collateral
-    function maxDebtForCollateral(uint256 collateralAmount) public view returns (uint256) {
+    function maxDebtForCollateral(
+        uint256 collateralAmount
+    ) public view returns (uint256) {
         uint256 creditMultiplier = ProfitManager(refs.profitManager)
             .creditMultiplier();
         return _maxDebtForCollateral(collateralAmount, creditMultiplier);
     }
 
     /// @notice maximum debt for a given amount of collateral & creditMultiplier
-    function _maxDebtForCollateral(uint256 collateralAmount, uint256 creditMultiplier) internal view returns (uint256) {
-        return (collateralAmount *
-            params.maxDebtPerCollateralToken) / creditMultiplier;
+    function _maxDebtForCollateral(
+        uint256 collateralAmount,
+        uint256 creditMultiplier
+    ) internal view returns (uint256) {
+        return
+            (collateralAmount * params.maxDebtPerCollateralToken) /
+            creditMultiplier;
     }
 
     /// @notice returns true if the term has a maximum delay between partial repays
@@ -392,7 +401,10 @@ contract LendingTerm is CoreRef {
         // check that enough collateral is provided
         uint256 creditMultiplier = ProfitManager(refs.profitManager)
             .creditMultiplier();
-        uint256 maxBorrow = _maxDebtForCollateral(collateralAmount, creditMultiplier);
+        uint256 maxBorrow = _maxDebtForCollateral(
+            collateralAmount,
+            creditMultiplier
+        );
         require(
             borrowAmount <= maxBorrow,
             "LendingTerm: not enough collateral"
@@ -699,7 +711,11 @@ contract LendingTerm is CoreRef {
         uint256 loanDebt = _getLoanDebt(loanId, creditMultiplier);
         require(
             GuildToken(refs.guildToken).isDeprecatedGauge(address(this)) ||
-                loanDebt > _maxDebtForCollateral(loans[loanId].collateralAmount, creditMultiplier) ||
+                loanDebt >
+                _maxDebtForCollateral(
+                    loans[loanId].collateralAmount,
+                    creditMultiplier
+                ) ||
                 partialRepayDelayPassed(loanId),
             "LendingTerm: cannot call"
         );

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -680,7 +680,7 @@ contract LendingTerm is CoreRef {
         loans[loanId].caller = caller;
 
         // auction the loan collateral
-        AuctionHouse(_auctionHouse).startAuction(loanId, loanDebt);
+        AuctionHouse(_auctionHouse).startAuction(loanId);
 
         // emit event
         emit LoanCall(block.timestamp, loanId);

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -733,17 +733,15 @@ contract LendingTerm is CoreRef {
 
         // close the loan
         loans[loanId].closeTime = block.timestamp;
-        issuance -= loan.borrowAmount;
+        uint256 borrowAmount = loans[loanId].borrowAmount;
+        issuance -= borrowAmount;
 
         // mark loan as a total loss
         uint256 creditMultiplier = ProfitManager(refs.profitManager)
             .creditMultiplier();
-        uint256 borrowAmount = loans[loanId].borrowAmount;
         uint256 principal = (borrowAmount *
             loans[loanId].borrowCreditMultiplier) / creditMultiplier;
         int256 pnl = -int256(principal);
-        // set hardcap to 0 to prevent new borrows
-        params.hardCap = 0;
         ProfitManager(refs.profitManager).notifyPnL(
             address(this),
             pnl,

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -192,6 +192,16 @@ contract LendingTerm is CoreRef {
         return params.collateralToken;
     }
 
+    /// @notice get reference 'profitManager' of this term
+    function profitManager() external view returns (address) {
+        return refs.profitManager;
+    }
+
+    /// @notice get reference 'creditToken' of this term
+    function creditToken() external view returns (address) {
+        return refs.creditToken;
+    }
+
     /// @notice get a loan
     function getLoan(bytes32 loanId) external view returns (Loan memory) {
         return loans[loanId];

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -326,8 +326,8 @@ contract LendingTerm is CoreRef {
         }
         uint256 toleratedGaugeWeight = (gaugeWeight * gaugeWeightTolerance) /
             1e18;
-        uint256 debtCeilingBefore = (totalIssuance *
-            toleratedGaugeWeight) / totalWeight;
+        uint256 debtCeilingBefore = (totalIssuance * toleratedGaugeWeight) /
+            totalWeight;
         // if already above cap, no more borrows allowed
         if (_issuance >= debtCeilingBefore) {
             return debtCeilingBefore;
@@ -535,14 +535,15 @@ contract LendingTerm is CoreRef {
         uint256 borrowAmount = loan.borrowAmount;
         uint256 creditMultiplier = ProfitManager(refs.profitManager)
             .creditMultiplier();
-        uint256 principalRepaid = (borrowAmount * loan.borrowCreditMultiplier * debtToRepay) / creditMultiplier / loanDebt;
+        uint256 principalRepaid = (borrowAmount *
+            loan.borrowCreditMultiplier *
+            debtToRepay) /
+            creditMultiplier /
+            loanDebt;
         uint256 interestRepaid = debtToRepay - principalRepaid;
         uint256 issuanceDecrease = (borrowAmount * debtToRepay) / loanDebt;
 
-        require(
-            principalRepaid != 0,
-            "LendingTerm: repay too small"
-        );
+        require(principalRepaid != 0, "LendingTerm: repay too small");
         require(
             debtToRepay >= (loanDebt * params.minPartialRepayPercent) / 1e18,
             "LendingTerm: repay below min"

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -202,6 +202,11 @@ contract LendingTerm is CoreRef {
         return refs.creditToken;
     }
 
+    /// @notice get reference 'auctionHouse' of this term
+    function auctionHouse() external view returns (address) {
+        return refs.auctionHouse;
+    }
+
     /// @notice get a loan
     function getLoan(bytes32 loanId) external view returns (Loan memory) {
         return loans[loanId];

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -532,17 +532,15 @@ contract LendingTerm is CoreRef {
         // compute partial repayment
         uint256 loanDebt = getLoanDebt(loanId);
         require(debtToRepay < loanDebt, "LendingTerm: full repayment");
-        uint256 percentRepaid = (debtToRepay * 1e18) / loanDebt; // [0, 1e18[
         uint256 borrowAmount = loan.borrowAmount;
         uint256 creditMultiplier = ProfitManager(refs.profitManager)
             .creditMultiplier();
-        uint256 principal = (borrowAmount * loan.borrowCreditMultiplier) /
-            creditMultiplier;
-        uint256 principalRepaid = (principal * percentRepaid) / 1e18;
+        uint256 principalRepaid = (borrowAmount * loan.borrowCreditMultiplier * debtToRepay) / creditMultiplier / loanDebt;
         uint256 interestRepaid = debtToRepay - principalRepaid;
-        uint256 issuanceDecrease = (borrowAmount * percentRepaid) / 1e18;
+        uint256 issuanceDecrease = (borrowAmount * debtToRepay) / loanDebt;
+
         require(
-            principalRepaid != 0 && interestRepaid != 0,
+            principalRepaid != 0,
             "LendingTerm: repay too small"
         );
         require(

--- a/src/loan/SurplusGuildMinter.sol
+++ b/src/loan/SurplusGuildMinter.sol
@@ -242,7 +242,7 @@ contract SurplusGuildMinter is CoreRef {
             return (lastGaugeLoss, userStake, slashed);
 
         // compute CREDIT rewards
-        ProfitManager(profitManager).claimRewards(address(this)); // this will update profit indexes
+        ProfitManager(profitManager).claimGaugeRewards(address(this), term); // this will update profit indexes
         uint256 _profitIndex = ProfitManager(profitManager)
             .userGaugeProfitIndex(address(this), term);
         uint256 _userProfitIndex = uint256(userStake.profitIndex);

--- a/src/loan/SurplusGuildMinter.sol
+++ b/src/loan/SurplusGuildMinter.sol
@@ -6,6 +6,7 @@ import {SafeCastLib} from "@solmate/src/utils/SafeCastLib.sol";
 import {CoreRef} from "@src/core/CoreRef.sol";
 import {CoreRoles} from "@src/core/CoreRoles.sol";
 import {GuildToken} from "@src/tokens/GuildToken.sol";
+import {LendingTerm} from "@src/loan/LendingTerm.sol";
 import {CreditToken} from "@src/tokens/CreditToken.sol";
 import {ProfitManager} from "@src/governance/ProfitManager.sol";
 import {RateLimitedMinter} from "@src/rate-limits/RateLimitedMinter.sol";
@@ -123,6 +124,11 @@ contract SurplusGuildMinter is CoreRef {
             "SurplusGuildMinter: loss in block"
         );
         require(amount >= MIN_STAKE, "SurplusGuildMinter: min stake");
+
+        // check that the term is from the same market
+        // if this test passes, the GUILD token will still check that the term is an active
+        // gauge, so a forged term that would return the same creditToken address cannot be passed.
+        require(LendingTerm(term).creditToken() == credit, "SurplusGuildMinter: invalid term");
 
         // pull CREDIT from user & transfer it to surplus buffer
         CreditToken(credit).transferFrom(msg.sender, address(this), amount);

--- a/src/loan/SurplusGuildMinter.sol
+++ b/src/loan/SurplusGuildMinter.sol
@@ -128,7 +128,10 @@ contract SurplusGuildMinter is CoreRef {
         // check that the term is from the same market
         // if this test passes, the GUILD token will still check that the term is an active
         // gauge, so a forged term that would return the same creditToken address cannot be passed.
-        require(LendingTerm(term).creditToken() == credit, "SurplusGuildMinter: invalid term");
+        require(
+            LendingTerm(term).creditToken() == credit,
+            "SurplusGuildMinter: invalid term"
+        );
 
         // pull CREDIT from user & transfer it to surplus buffer
         CreditToken(credit).transferFrom(msg.sender, address(this), amount);

--- a/src/loan/SurplusGuildMinter.sol
+++ b/src/loan/SurplusGuildMinter.sol
@@ -232,12 +232,12 @@ contract SurplusGuildMinter is CoreRef {
     {
         bool updateState;
         lastGaugeLoss = GuildToken(guild).lastGaugeLoss(term);
+        userStake = _stakes[user][term];
         if (lastGaugeLoss > uint256(userStake.lastGaugeLoss)) {
             slashed = true;
         }
 
         // if the user is not staking, do nothing
-        userStake = _stakes[user][term];
         if (userStake.stakeTime == 0)
             return (lastGaugeLoss, userStake, slashed);
 

--- a/src/rate-limits/RateLimitedMinter.sol
+++ b/src/rate-limits/RateLimitedMinter.sol
@@ -5,15 +5,11 @@ import {CoreRef} from "@src/core/CoreRef.sol";
 import {CoreRoles} from "@src/core/CoreRoles.sol";
 import {RateLimitedV2} from "@src/utils/RateLimitedV2.sol";
 
-import {CreditToken} from "@src/tokens/CreditToken.sol";
-
 interface IERC20Mintable {
     function mint(address to, uint256 amount) external;
 }
 
 /// @notice contract to mint tokens on a rate limit.
-/// All minting should flow through this smart contract, as it should be the only one with
-/// minting capabilities.
 contract RateLimitedMinter is RateLimitedV2 {
     /// @notice the reference to token
     address public immutable token;

--- a/src/rate-limits/RateLimitedMinter.sol
+++ b/src/rate-limits/RateLimitedMinter.sol
@@ -45,7 +45,7 @@ contract RateLimitedMinter is RateLimitedV2 {
     function mint(
         address to,
         uint256 amount
-    ) external onlyCoreRole(role) whenNotPaused {
+    ) external onlyCoreRole(role) {
         _depleteBuffer(amount); /// check and effects
         IERC20Mintable(token).mint(to, amount); /// interactions
     }

--- a/src/rate-limits/RateLimitedMinter.sol
+++ b/src/rate-limits/RateLimitedMinter.sol
@@ -42,10 +42,7 @@ contract RateLimitedMinter is RateLimitedV2 {
     /// Pausable and depletes the buffer, reverts if buffer is used.
     /// @param to the recipient address of the minted tokens.
     /// @param amount the amount of tokens to mint.
-    function mint(
-        address to,
-        uint256 amount
-    ) external onlyCoreRole(role) {
+    function mint(address to, uint256 amount) external onlyCoreRole(role) {
         _depleteBuffer(amount); /// check and effects
         IERC20Mintable(token).mint(to, amount); /// interactions
     }

--- a/src/tokens/CreditToken.sol
+++ b/src/tokens/CreditToken.sol
@@ -65,6 +65,13 @@ contract CreditToken is
         _setContractExceedMaxDelegates(account, canExceedMax);
     }
 
+    /// @notice Set the lockup period after delegating votes
+    function setDelegateLockupPeriod(
+        uint256 newValue
+    ) external onlyCoreRole(CoreRoles.CREDIT_GOVERNANCE_PARAMETERS) {
+        _setDelegateLockupPeriod(newValue);
+    }
+
     /// @notice Force an address to enter rebase.
     function forceEnterRebase(
         address account
@@ -103,6 +110,7 @@ contract CreditToken is
         uint256 amount
     ) internal override(ERC20, ERC20MultiVotes, ERC20RebaseDistributor) {
         _decrementVotesUntilFree(account, amount); // from ERC20MultiVotes
+        _checkDelegateLockupPeriod(account); // from ERC20MultiVotes
         ERC20RebaseDistributor._burn(account, amount);
     }
 
@@ -130,6 +138,7 @@ contract CreditToken is
         returns (bool)
     {
         _decrementVotesUntilFree(msg.sender, amount); // from ERC20MultiVotes
+        _checkDelegateLockupPeriod(msg.sender); // from ERC20MultiVotes
         return ERC20RebaseDistributor.transfer(to, amount);
     }
 
@@ -143,6 +152,7 @@ contract CreditToken is
         returns (bool)
     {
         _decrementVotesUntilFree(from, amount); // from ERC20MultiVotes
+        _checkDelegateLockupPeriod(from); // from ERC20MultiVotes
         return ERC20RebaseDistributor.transferFrom(from, to, amount);
     }
 }

--- a/src/tokens/CreditToken.sol
+++ b/src/tokens/CreditToken.sol
@@ -25,11 +25,7 @@ contract CreditToken is
         address _core,
         string memory _name,
         string memory _symbol
-    )
-        CoreRef(_core)
-        ERC20(_name, _symbol)
-        ERC20Permit(_name)
-    {}
+    ) CoreRef(_core) ERC20(_name, _symbol) ERC20Permit(_name) {}
 
     /// @notice Mint new tokens to the target address
     function mint(

--- a/src/tokens/CreditToken.sol
+++ b/src/tokens/CreditToken.sol
@@ -35,6 +35,21 @@ contract CreditToken is
         _mint(to, amount);
     }
 
+    /// @notice Destroys `amount` tokens from the caller.
+    function burn(
+        uint256 amount
+    ) public override onlyCoreRole(CoreRoles.CREDIT_BURNER) {
+        super.burn(amount);
+    }
+
+    /// @notice Destroys `amount` tokens from `account`, deducting from the caller's allowance.
+    function burnFrom(
+        address account,
+        uint256 amount
+    ) public override onlyCoreRole(CoreRoles.CREDIT_BURNER) {
+        super.burnFrom(account, amount);
+    }
+
     /// @notice Set `maxDelegates`, the maximum number of addresses any account can delegate voting power to.
     function setMaxDelegates(
         uint256 newMax

--- a/src/tokens/ERC20Gauges.sol
+++ b/src/tokens/ERC20Gauges.sol
@@ -41,8 +41,6 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
         ... Add internal _setMaxGauges(uint256) method
     - Remove public setContractExceedMaxGauges(address, bool) requiresAuth method
         ... Add internal _setCanExceedMaxGauges(address, bool) method
-        ... Remove check of "target address has nonzero code size"
-        ... Rename to remove "contract" from name because we don't check if target is a contract
     - Rename `calculateGaugeAllocation` to `calculateGaugeStoredAllocation` to make clear that it reads from stored weights.
     - Add `calculateGaugeAllocation` helper function that reads from current weight.
     - Add `isDeprecatedGauge(address)->bool` view function that returns true if gauge is deprecated.
@@ -528,10 +526,9 @@ abstract contract ERC20Gauges is ERC20 {
                     totalTypeWeight[gaugeType[gauge]] -= userGaugeWeight;
                     totalFreed += userGaugeWeight;
                 }
-
-                unchecked {
-                    ++i;
-                }
+            }
+            unchecked {
+                ++i;
             }
         }
 

--- a/src/tokens/ERC20MultiVotes.sol
+++ b/src/tokens/ERC20MultiVotes.sol
@@ -143,7 +143,10 @@ abstract contract ERC20MultiVotes is ERC20Permit {
     /// @notice an approve list for contracts to go above the max delegate limit.
     mapping(address => bool) public canContractExceedMaxDelegates;
 
-    /// @notice set the new max delegates per user. Requires auth by `authority`.
+    /// @notice set the new max delegates per user.
+    /// Does not prevent delegation updates to existing delegates, and does not
+    /// force undelegation to existing delegates, if the maxDelegates is set to
+    /// a lower value and delegators have existing delegatees.
     function _setMaxDelegates(uint256 newMax) internal {
         uint256 oldMax = maxDelegates;
         maxDelegates = newMax;

--- a/src/tokens/ERC20RebaseDistributor.sol
+++ b/src/tokens/ERC20RebaseDistributor.sol
@@ -322,7 +322,8 @@ abstract contract ERC20RebaseDistributor is ERC20 {
                     _unmintedRebaseRewards - mintAmount
                 ), // adjusted current
                 targetTimestamp: val.targetTimestamp, // unchanged
-                targetValue: val.targetValue - SafeCastLib.safeCastTo224(mintAmount) // adjusted target
+                targetValue: val.targetValue -
+                    SafeCastLib.safeCastTo224(mintAmount) // adjusted target
             });
 
             emit RebaseReward(account, block.timestamp, mintAmount);

--- a/src/tokens/ERC20RebaseDistributor.sol
+++ b/src/tokens/ERC20RebaseDistributor.sol
@@ -53,6 +53,7 @@ abstract contract ERC20RebaseDistributor is ERC20 {
         address indexed source,
         uint256 indexed timestamp,
         uint256 amountDistributed,
+        uint256 totalPendingDistributions,
         uint256 amountRebasing
     );
     /// @notice Emitted when an `amount` of tokens is realized as rebase rewards for `account`.
@@ -353,12 +354,6 @@ abstract contract ERC20RebaseDistributor is ERC20 {
             0,
             0
         );
-        emit RebaseDistribution(
-            msg.sender,
-            block.timestamp,
-            amount,
-            _rebasingSupply
-        );
 
         // adjust up the balance of all accounts that are rebasing by increasing
         // the share price of rebasing tokens
@@ -385,6 +380,22 @@ abstract contract ERC20RebaseDistributor is ERC20 {
                 targetValue: __unmintedRebaseRewards.targetValue +
                     SafeCastLib.safeCastTo224(amount)
             });
+
+            emit RebaseDistribution(
+                msg.sender,
+                block.timestamp,
+                amount,
+                _unmintedRebaseRewards,
+                _rebasingSupply
+            );
+        } else {
+            emit RebaseDistribution(
+                msg.sender,
+                block.timestamp,
+                amount,
+                0,
+                _rebasingSupply
+            );
         }
     }
 

--- a/src/tokens/ERC20RebaseDistributor.sol
+++ b/src/tokens/ERC20RebaseDistributor.sol
@@ -153,15 +153,7 @@ abstract contract ERC20RebaseDistributor is ERC20 {
     }
 
     /// @notice called to update the number of rebasing shares.
-    /// This can happen in multiple situations:
-    /// - enterRebase()
-    /// - exitRebase()
-    /// - burn() from a rebasing address
-    /// - mint() to a rebasing address
-    /// - transfer() from a rebasing address
-    /// - transfer() to a rebasing address
-    /// - transferFrom() from a rebasing address
-    /// - transferFrom() to a rebasing address
+    /// This can happen in enterRebase() or exitRebase().
     /// If the number of shares is updated during the interpolation, the target share price
     /// of the interpolation should be changed to reflect the reduced or increased number of shares
     /// and keep a constant rebasing supply value (current & target).
@@ -181,11 +173,13 @@ abstract contract ERC20RebaseDistributor is ERC20 {
                     sharesAfter = sharesBefore - shareDecrease;
                 }
             }
-            // else sharesAfter stays 0
+            // else sharesAfter is 0
         }
         totalRebasingShares = sharesAfter;
 
         // reset interpolation & share price if going to 0 rebasing supply
+        /// @dev this resets the contract to its initial state, and is only possible
+        /// if all users have exited rebase.
         if (sharesAfter == 0) {
             __rebasingSharePrice = InterpolatedValue({
                 lastTimestamp: SafeCastLib.safeCastTo32(block.timestamp), // now
@@ -222,20 +216,6 @@ abstract contract ERC20RebaseDistributor is ERC20 {
                 targetValue: SafeCastLib.safeCastTo224(targetNewSharePrice) // adjusted target
             });
         }
-    }
-
-    /// @notice decrease unminted rebase rewards, when rewards are minted to users
-    function decreaseUnmintedRebaseRewards(uint256 amount) internal {
-        InterpolatedValue memory val = __unmintedRebaseRewards;
-        uint256 _unmintedRebaseRewards = interpolatedValue(val);
-        __unmintedRebaseRewards = InterpolatedValue({
-            lastTimestamp: SafeCastLib.safeCastTo32(block.timestamp), // now
-            lastValue: SafeCastLib.safeCastTo224(
-                _unmintedRebaseRewards - amount
-            ), // adjusted current
-            targetTimestamp: val.targetTimestamp, // unchanged
-            targetValue: val.targetValue - SafeCastLib.safeCastTo224(amount) // adjusted target
-        });
     }
 
     /// @notice get the current rebasing share price
@@ -335,7 +315,16 @@ abstract contract ERC20RebaseDistributor is ERC20 {
 
         if (mintAmount != 0) {
             ERC20._mint(account, mintAmount);
-            decreaseUnmintedRebaseRewards(mintAmount);
+
+            __unmintedRebaseRewards = InterpolatedValue({
+                lastTimestamp: SafeCastLib.safeCastTo32(block.timestamp), // now
+                lastValue: SafeCastLib.safeCastTo224(
+                    _unmintedRebaseRewards - mintAmount
+                ), // adjusted current
+                targetTimestamp: val.targetTimestamp, // unchanged
+                targetValue: val.targetValue - SafeCastLib.safeCastTo224(mintAmount) // adjusted target
+            });
+
             emit RebaseReward(account, block.timestamp, mintAmount);
         }
 
@@ -474,90 +463,33 @@ abstract contract ERC20RebaseDistributor is ERC20 {
     function _burn(address account, uint256 amount) internal virtual override {
         // if `account` is rebasing, materialize the tokens from rebase first, to ensure
         // proper behavior in `ERC20._burn()`.
-        RebasingState memory _rebasingState = rebasingState[account];
-        uint256 balanceBefore;
-        uint256 _rebasingSharePrice;
-        if (_rebasingState.isRebasing == 1) {
-            balanceBefore = ERC20.balanceOf(account);
-            _rebasingSharePrice = rebasingSharePrice();
-            uint256 rebasedBalance = _shares2balance(
-                _rebasingState.nShares,
-                _rebasingSharePrice,
-                0,
-                balanceBefore
-            );
-            uint256 mintAmount = rebasedBalance - balanceBefore;
-            if (mintAmount != 0) {
-                ERC20._mint(account, mintAmount);
-                balanceBefore += mintAmount;
-                decreaseUnmintedRebaseRewards(mintAmount);
-                emit RebaseReward(account, block.timestamp, mintAmount);
-            }
+        bool isUserRebasing = rebasingState[account].isRebasing == 1;
+        if (isUserRebasing) {
+            _exitRebase(account);
         }
 
         // do ERC20._burn()
         ERC20._burn(account, amount);
 
-        // if `account` is rebasing, update its number of shares
-        if (_rebasingState.isRebasing == 1) {
-            uint256 balanceAfter = balanceBefore - amount;
-            uint256 sharesAfter = _balance2shares(
-                balanceAfter,
-                _rebasingSharePrice
-            );
-            uint256 sharesBurnt = _rebasingState.nShares - sharesAfter;
-            rebasingState[account] = RebasingState({
-                isRebasing: 1,
-                nShares: uint248(sharesAfter)
-            });
-            updateTotalRebasingShares(
-                _rebasingSharePrice,
-                -int256(sharesBurnt)
-            );
+        // re-enter rebasing if needed
+        if (isUserRebasing) {
+            _enterRebase(account);
         }
     }
 
     /// @notice Override of default ERC20 behavior: exit rebase before movement (if rebasing),
     /// and re-enter rebasing after movement (if rebasing).
     function _mint(address account, uint256 amount) internal virtual override {
+        bool isUserRebasing = rebasingState[account].isRebasing == 1;
+        if (isUserRebasing) {
+            _exitRebase(account);
+        }
+
         // do ERC20._mint()
         ERC20._mint(account, amount);
 
-        // if `account` is rebasing, update its number of shares
-        RebasingState memory _rebasingState = rebasingState[account];
-        if (_rebasingState.isRebasing == 1) {
-            // compute rebased balance
-            uint256 _rebasingSharePrice = rebasingSharePrice();
-            uint256 rawBalance = ERC20.balanceOf(account);
-            uint256 rebasedBalance = _shares2balance(
-                _rebasingState.nShares,
-                _rebasingSharePrice,
-                amount,
-                rawBalance
-            );
-
-            // update number of shares
-            uint256 sharesAfter = _balance2shares(
-                rebasedBalance,
-                _rebasingSharePrice
-            );
-            uint256 sharesReceived = sharesAfter - _rebasingState.nShares;
-            rebasingState[account] = RebasingState({
-                isRebasing: 1,
-                nShares: uint248(sharesAfter)
-            });
-            updateTotalRebasingShares(
-                _rebasingSharePrice,
-                int256(sharesReceived)
-            );
-
-            // "realize" unminted rebase rewards
-            uint256 mintAmount = rebasedBalance - rawBalance;
-            if (mintAmount != 0) {
-                ERC20._mint(account, mintAmount);
-                decreaseUnmintedRebaseRewards(mintAmount);
-                emit RebaseReward(account, block.timestamp, mintAmount);
-            }
+        if (isUserRebasing) {
+            _enterRebase(account);
         }
     }
 
@@ -567,88 +499,23 @@ abstract contract ERC20RebaseDistributor is ERC20 {
         address to,
         uint256 amount
     ) public virtual override returns (bool) {
-        // if `from` is rebasing, materialize the tokens from rebase to ensure
-        // proper behavior in `ERC20.transfer()`.
-        RebasingState memory rebasingStateFrom = rebasingState[msg.sender];
-        RebasingState memory rebasingStateTo = rebasingState[to];
-        uint256 fromBalanceBefore = ERC20.balanceOf(msg.sender);
-        uint256 _rebasingSharePrice = (rebasingStateFrom.isRebasing == 1 ||
-            rebasingStateTo.isRebasing == 1)
-            ? rebasingSharePrice()
-            : 0; // only SLOAD if at least one address is rebasing
-        if (rebasingStateFrom.isRebasing == 1) {
-            uint256 shares = uint256(rebasingStateFrom.nShares);
-            uint256 rebasedBalance = _shares2balance(
-                shares,
-                _rebasingSharePrice,
-                0,
-                fromBalanceBefore
-            );
-            uint256 mintAmount = rebasedBalance - fromBalanceBefore;
-            if (mintAmount != 0) {
-                ERC20._mint(msg.sender, mintAmount);
-                fromBalanceBefore += mintAmount;
-                decreaseUnmintedRebaseRewards(mintAmount);
-                emit RebaseReward(msg.sender, block.timestamp, mintAmount);
-            }
+        bool isRebasingFrom = rebasingState[msg.sender].isRebasing == 1;
+        bool isRebasingTo = rebasingState[to].isRebasing == 1;
+        if (isRebasingFrom) {
+            _exitRebase(msg.sender);
+        }
+        if (isRebasingTo && to != msg.sender) {
+            _exitRebase(to);
         }
 
         // do ERC20.transfer()
         bool success = ERC20.transfer(to, amount);
 
-        // if `from` is rebasing, update its number of shares
-        int256 sharesDelta;
-        if (rebasingStateFrom.isRebasing == 1) {
-            uint256 fromBalanceAfter = fromBalanceBefore - amount;
-            uint256 fromSharesAfter = _balance2shares(
-                fromBalanceAfter,
-                _rebasingSharePrice
-            );
-            uint256 sharesSpent = rebasingStateFrom.nShares - fromSharesAfter;
-            sharesDelta -= int256(sharesSpent);
-            rebasingState[msg.sender] = RebasingState({
-                isRebasing: 1,
-                nShares: uint248(fromSharesAfter)
-            });
+        if (isRebasingFrom) {
+            _enterRebase(msg.sender);
         }
-
-        // if `to` is rebasing, update its number of shares
-        if (rebasingStateTo.isRebasing == 1) {
-            // compute rebased balance
-            uint256 rawToBalanceAfter = ERC20.balanceOf(to);
-            uint256 toBalanceAfter = _shares2balance(
-                rebasingStateTo.nShares,
-                _rebasingSharePrice,
-                amount,
-                rawToBalanceAfter
-            );
-
-            // update number of shares
-            uint256 toSharesAfter = _balance2shares(
-                toBalanceAfter,
-                _rebasingSharePrice
-            );
-            uint256 sharesReceived = toSharesAfter - rebasingStateTo.nShares;
-            sharesDelta += int256(sharesReceived);
-            rebasingState[to] = RebasingState({
-                isRebasing: 1,
-                nShares: uint248(toSharesAfter)
-            });
-
-            // "realize" unminted rebase rewards
-            uint256 mintAmount = toBalanceAfter - rawToBalanceAfter;
-            if (mintAmount != 0) {
-                ERC20._mint(to, mintAmount);
-                decreaseUnmintedRebaseRewards(mintAmount);
-                emit RebaseReward(to, block.timestamp, mintAmount);
-            }
-        }
-
-        // if `from` or `to` was rebasing, update the total number of shares
-        if (
-            rebasingStateFrom.isRebasing == 1 || rebasingStateTo.isRebasing == 1
-        ) {
-            updateTotalRebasingShares(_rebasingSharePrice, sharesDelta);
+        if (isRebasingTo && to != msg.sender) {
+            _enterRebase(to);
         }
 
         return success;
@@ -661,88 +528,23 @@ abstract contract ERC20RebaseDistributor is ERC20 {
         address to,
         uint256 amount
     ) public virtual override returns (bool) {
-        // if `from` is rebasing, materialize the tokens from rebase to ensure
-        // proper behavior in `ERC20.transfer()`.
-        RebasingState memory rebasingStateFrom = rebasingState[from];
-        RebasingState memory rebasingStateTo = rebasingState[to];
-        uint256 fromBalanceBefore = ERC20.balanceOf(from);
-        uint256 _rebasingSharePrice = (rebasingStateFrom.isRebasing == 1 ||
-            rebasingStateTo.isRebasing == 1)
-            ? rebasingSharePrice()
-            : 0;
-        if (rebasingStateFrom.isRebasing == 1) {
-            uint256 shares = uint256(rebasingStateFrom.nShares);
-            uint256 rebasedBalance = _shares2balance(
-                shares,
-                _rebasingSharePrice,
-                0,
-                fromBalanceBefore
-            );
-            uint256 mintAmount = rebasedBalance - fromBalanceBefore;
-            if (mintAmount != 0) {
-                ERC20._mint(from, mintAmount);
-                fromBalanceBefore += mintAmount;
-                decreaseUnmintedRebaseRewards(mintAmount);
-                emit RebaseReward(from, block.timestamp, mintAmount);
-            }
+        bool isRebasingFrom = rebasingState[from].isRebasing == 1;
+        bool isRebasingTo = rebasingState[to].isRebasing == 1;
+        if (isRebasingFrom) {
+            _exitRebase(from);
+        }
+        if (isRebasingTo && to != from) {
+            _exitRebase(to);
         }
 
         // do ERC20.transferFrom()
         bool success = ERC20.transferFrom(from, to, amount);
 
-        // if `from` is rebasing, update its number of shares
-        int256 sharesDelta;
-        if (rebasingStateFrom.isRebasing == 1) {
-            uint256 fromBalanceAfter = fromBalanceBefore - amount;
-            uint256 fromSharesAfter = _balance2shares(
-                fromBalanceAfter,
-                _rebasingSharePrice
-            );
-            uint256 sharesSpent = rebasingStateFrom.nShares - fromSharesAfter;
-            sharesDelta -= int256(sharesSpent);
-            rebasingState[from] = RebasingState({
-                isRebasing: 1,
-                nShares: uint248(fromSharesAfter)
-            });
+        if (isRebasingFrom) {
+            _enterRebase(from);
         }
-
-        // if `to` is rebasing, update its number of shares
-        if (rebasingStateTo.isRebasing == 1) {
-            // compute rebased balance
-            uint256 rawToBalanceAfter = ERC20.balanceOf(to);
-            uint256 toBalanceAfter = _shares2balance(
-                rebasingStateTo.nShares,
-                _rebasingSharePrice,
-                amount,
-                rawToBalanceAfter
-            );
-
-            // update number of shares
-            uint256 toSharesAfter = _balance2shares(
-                toBalanceAfter,
-                _rebasingSharePrice
-            );
-            uint256 sharesReceived = toSharesAfter - rebasingStateTo.nShares;
-            sharesDelta += int256(sharesReceived);
-            rebasingState[to] = RebasingState({
-                isRebasing: 1,
-                nShares: uint248(toSharesAfter)
-            });
-
-            // "realize" unminted rebase rewards
-            uint256 mintAmount = toBalanceAfter - rawToBalanceAfter;
-            if (mintAmount != 0) {
-                ERC20._mint(to, mintAmount);
-                decreaseUnmintedRebaseRewards(mintAmount);
-                emit RebaseReward(to, block.timestamp, mintAmount);
-            }
-        }
-
-        // if `from` or `to` was rebasing, update the total number of shares
-        if (
-            rebasingStateFrom.isRebasing == 1 || rebasingStateTo.isRebasing == 1
-        ) {
-            updateTotalRebasingShares(_rebasingSharePrice, sharesDelta);
+        if (isRebasingTo && to != from) {
+            _enterRebase(to);
         }
 
         return success;

--- a/src/tokens/GuildToken.sol
+++ b/src/tokens/GuildToken.sol
@@ -201,13 +201,16 @@ contract GuildToken is CoreRef, ERC20Burnable, ERC20Gauges, ERC20MultiVotes {
             _lastGaugeLossApplied >= _lastGaugeLoss,
             "GuildToken: pending loss"
         );
+        uint256 issuance = LendingTerm(gauge).issuance();
+        if (isDeprecatedGauge(gauge)) {
+            require(issuance == 0, "GuildToken: not all loans closed");
+        }
 
         // update the user profit index and claim rewards
         ProfitManager(LendingTerm(gauge).profitManager()).claimGaugeRewards(user, gauge);
 
         // check if gauge is currently using its allocated debt ceiling.
         // To decrement gauge weight, guild holders might have to call loans if the debt ceiling is used.
-        uint256 issuance = LendingTerm(gauge).issuance();
         if (issuance != 0) {
             uint256 debtCeilingAfterDecrement = LendingTerm(gauge).debtCeiling(-int256(weight));
             require(

--- a/src/tokens/GuildToken.sol
+++ b/src/tokens/GuildToken.sol
@@ -64,6 +64,13 @@ contract GuildToken is CoreRef, ERC20Burnable, ERC20Gauges, ERC20MultiVotes {
         _setContractExceedMaxDelegates(account, canExceedMax);
     }
 
+    /// @notice Set the lockup period after delegating votes
+    function setDelegateLockupPeriod(
+        uint256 newValue
+    ) external onlyCoreRole(CoreRoles.GUILD_GOVERNANCE_PARAMETERS) {
+        _setDelegateLockupPeriod(newValue);
+    }
+
     /*///////////////////////////////////////////////////////////////
                         GAUGE MANAGEMENT
     //////////////////////////////////////////////////////////////*/
@@ -282,6 +289,7 @@ contract GuildToken is CoreRef, ERC20Burnable, ERC20Gauges, ERC20MultiVotes {
     ) internal virtual override(ERC20, ERC20Gauges, ERC20MultiVotes) {
         _decrementWeightUntilFree(from, amount);
         _decrementVotesUntilFree(from, amount);
+        _checkDelegateLockupPeriod(from);
         ERC20._burn(from, amount);
     }
 
@@ -296,6 +304,7 @@ contract GuildToken is CoreRef, ERC20Burnable, ERC20Gauges, ERC20MultiVotes {
     {
         _decrementWeightUntilFree(msg.sender, amount);
         _decrementVotesUntilFree(msg.sender, amount);
+        _checkDelegateLockupPeriod(msg.sender);
         return ERC20.transfer(to, amount);
     }
 
@@ -311,6 +320,7 @@ contract GuildToken is CoreRef, ERC20Burnable, ERC20Gauges, ERC20MultiVotes {
     {
         _decrementWeightUntilFree(from, amount);
         _decrementVotesUntilFree(from, amount);
+        _checkDelegateLockupPeriod(from);
         return ERC20.transferFrom(from, to, amount);
     }
 }

--- a/src/tokens/GuildToken.sol
+++ b/src/tokens/GuildToken.sol
@@ -139,11 +139,11 @@ contract GuildToken is CoreRef, ERC20Burnable, ERC20Gauges, ERC20MultiVotes {
 
         // remove gauge weight allocation
         lastGaugeLossApplied[gauge][who] = block.timestamp;
-        _decrementGaugeWeight(who, gauge, _userGaugeWeight);
         if (!_deprecatedGauges.contains(gauge)) {
             totalTypeWeight[gaugeType[gauge]] -= _userGaugeWeight;
             totalWeight -= _userGaugeWeight;
         }
+        _decrementGaugeWeight(who, gauge, _userGaugeWeight);
 
         // apply loss
         _burn(who, uint256(_userGaugeWeight));

--- a/src/tokens/GuildToken.sol
+++ b/src/tokens/GuildToken.sol
@@ -116,7 +116,10 @@ contract GuildToken is CoreRef, ERC20Burnable, ERC20Gauges, ERC20MultiVotes {
     /// @notice notify loss in a given gauge
     function notifyGaugeLoss(address gauge) external {
         require(_gauges.contains(gauge), "GuildToken: gauge not found");
-        require(msg.sender == LendingTerm(gauge).profitManager(), "UNAUTHORIZED");
+        require(
+            msg.sender == LendingTerm(gauge).profitManager(),
+            "UNAUTHORIZED"
+        );
 
         // save gauge loss
         lastGaugeLoss[gauge] = block.timestamp;
@@ -207,12 +210,17 @@ contract GuildToken is CoreRef, ERC20Burnable, ERC20Gauges, ERC20MultiVotes {
         }
 
         // update the user profit index and claim rewards
-        ProfitManager(LendingTerm(gauge).profitManager()).claimGaugeRewards(user, gauge);
+        ProfitManager(LendingTerm(gauge).profitManager()).claimGaugeRewards(
+            user,
+            gauge
+        );
 
         // check if gauge is currently using its allocated debt ceiling.
         // To decrement gauge weight, guild holders might have to call loans if the debt ceiling is used.
         if (issuance != 0) {
-            uint256 debtCeilingAfterDecrement = LendingTerm(gauge).debtCeiling(-int256(weight));
+            uint256 debtCeilingAfterDecrement = LendingTerm(gauge).debtCeiling(
+                -int256(weight)
+            );
             require(
                 issuance <= debtCeilingAfterDecrement,
                 "GuildToken: debt ceiling used"
@@ -244,7 +252,10 @@ contract GuildToken is CoreRef, ERC20Burnable, ERC20Gauges, ERC20MultiVotes {
             );
         }
 
-        ProfitManager(LendingTerm(gauge).profitManager()).claimGaugeRewards(user, gauge);
+        ProfitManager(LendingTerm(gauge).profitManager()).claimGaugeRewards(
+            user,
+            gauge
+        );
 
         super._incrementGaugeWeight(user, gauge, weight);
     }

--- a/test/integration/IntegrationTestDAOFlows.sol
+++ b/test/integration/IntegrationTestDAOFlows.sol
@@ -37,7 +37,9 @@ contract IntegrationTestDAOFlows is PostProposalCheckFixture {
         /// new term so that onboard succeeds
         term = LendingTerm(
             onboarder.createTerm(
+                1,
                 AddressLib.get("LENDING_TERM_V1"),
+                AddressLib.get("AUCTION_HOUSE"),
                 LendingTerm.LendingTermParams({
                     collateralToken: AddressLib.get("ERC20_SDAI"),
                     maxDebtPerCollateralToken: 1e18,

--- a/test/integration/IntegrationTestOffboardingFlows.sol
+++ b/test/integration/IntegrationTestOffboardingFlows.sol
@@ -35,7 +35,9 @@ contract IntegrationTestOffboardingFlows is PostProposalCheckFixture {
         /// new term so that onboard succeeds
         term = LendingTerm(
             onboarder.createTerm(
+                1,
                 AddressLib.get("LENDING_TERM_V1"),
+                AddressLib.get("AUCTION_HOUSE"),
                 LendingTerm.LendingTermParams({
                     collateralToken: AddressLib.get("ERC20_SDAI"),
                     maxDebtPerCollateralToken: 1e18,

--- a/test/integration/IntegrationTestOnboardOffboard.sol
+++ b/test/integration/IntegrationTestOnboardOffboard.sol
@@ -23,7 +23,9 @@ contract IntegrationTestOnboardOffboard is PostProposalCheckFixture {
         super.setUp();
         term = LendingTerm(
             onboarder.createTerm(
+                1,
                 AddressLib.get("LENDING_TERM_V1"),
+                AddressLib.get("AUCTION_HOUSE"),
                 LendingTerm.LendingTermParams({
                     collateralToken: AddressLib.get("ERC20_SDAI"),
                     maxDebtPerCollateralToken: 1e18,
@@ -145,7 +147,7 @@ contract IntegrationTestOnboardOffboard is PostProposalCheckFixture {
 
         _roleValidation();
 
-        assertTrue(offboarder.canOffboard(address(term)));
+        assertEq(uint8(offboarder.canOffboard(address(term))), 1);
 
         assertTrue(guild.isGauge(address(term)));
 
@@ -185,7 +187,7 @@ contract IntegrationTestOnboardOffboard is PostProposalCheckFixture {
 
         _roleValidation();
 
-        assertTrue(offboarder.canOffboard(address(term)));
+        assertEq(uint8(offboarder.canOffboard(address(term))), 1);
 
         assertTrue(guild.isGauge(address(term)));
 
@@ -210,11 +212,11 @@ contract IntegrationTestOnboardOffboard is PostProposalCheckFixture {
 
         offboarder.offboard(address(term));
 
-        assertTrue(offboarder.canOffboard(address(term)));
+        assertEq(uint8(offboarder.canOffboard(address(term))), 1);
         assertFalse(guild.isGauge(address(term)));
         offboarder.cleanup(address(term));
 
-        assertFalse(offboarder.canOffboard(address(term)));
+        assertEq(uint8(offboarder.canOffboard(address(term))), 0);
 
         assertFalse(core.hasRole(roles.GAUGE_PNL_NOTIFIER, address(term)));
         assertFalse(

--- a/test/integration/IntegrationTestOnboardingFlows.sol
+++ b/test/integration/IntegrationTestOnboardingFlows.sol
@@ -37,7 +37,9 @@ contract IntegrationTestOnboardingFlows is PostProposalCheckFixture {
         /// new term so that onboard succeeds
         term = LendingTerm(
             onboarder.createTerm(
+                1,
                 AddressLib.get("LENDING_TERM_V1"),
+                AddressLib.get("AUCTION_HOUSE"),
                 LendingTerm.LendingTermParams({
                     collateralToken: AddressLib.get("ERC20_SDAI"),
                     maxDebtPerCollateralToken: 1e18,

--- a/test/integration/IntegrationTestRoles.sol
+++ b/test/integration/IntegrationTestRoles.sol
@@ -27,7 +27,7 @@ contract IntegrationTestRoles is PostProposalCheck {
 
         string[] memory roles = vm.parseJsonKeys(json, "$");
 
-        assertEq(roles.length, 17, "incorrect role count");
+        assertEq(roles.length, 18, "incorrect role count");
         
         for (uint256 i = 0; i < roles.length; i++) {
             Core core = Core(AddressLib.get("CORE"));

--- a/test/integration/IntegrationTestVetoDAOFlows.sol
+++ b/test/integration/IntegrationTestVetoDAOFlows.sol
@@ -35,7 +35,9 @@ contract IntegrationTestVetoDAOFlows is PostProposalCheckFixture {
         /// new term so that onboard succeeds
         term = LendingTerm(
             onboarder.createTerm(
+                1,
                 AddressLib.get("LENDING_TERM_V1"),
+                AddressLib.get("AUCTION_HOUSE"),
                 LendingTerm.LendingTermParams({
                     collateralToken: AddressLib.get("ERC20_SDAI"),
                     maxDebtPerCollateralToken: 1e18,

--- a/test/mock/MockERC20MultiVotes.sol
+++ b/test/mock/MockERC20MultiVotes.sol
@@ -18,6 +18,10 @@ contract MockERC20MultiVotes is ERC20MultiVotes, MockERC20 {
         _setMaxDelegates(newMax);
     }
 
+    function setDelegateLockupPeriod(uint256 newValue) external {
+        _setDelegateLockupPeriod(newValue);
+    }
+
     function setContractExceedMaxDelegates(address account, bool canExceedMax) external {
         _setContractExceedMaxDelegates(account, canExceedMax);
     }

--- a/test/mock/MockLendingTerm.sol
+++ b/test/mock/MockLendingTerm.sol
@@ -5,6 +5,15 @@ import {CoreRef} from "@src/core/CoreRef.sol";
 
 contract MockLendingTerm is CoreRef {
     uint256 public issuance;
+    address public profitManager;
+    address public creditToken;
 
-    constructor(address core) CoreRef(core) {}
+    constructor(
+        address core,
+        address _profitManager,
+        address _creditToken
+    ) CoreRef(core) {
+        profitManager = _profitManager;
+        creditToken = _creditToken;
+    }
 }

--- a/test/proposals/gips/GIP_0.sol
+++ b/test/proposals/gips/GIP_0.sol
@@ -127,10 +127,7 @@ contract GIP_0 is Proposal {
                 "Ethereum Credit Guild - gUSDC",
                 "gUSDC"
             );
-            GuildToken guild = new GuildToken(
-                AddressLib.get("CORE"),
-                AddressLib.get("PROFIT_MANAGER")
-            );
+            GuildToken guild = new GuildToken(AddressLib.get("CORE"));
             RateLimitedMinter rateLimitedCreditMinter = new RateLimitedMinter(
                 AddressLib.get("CORE"),
                 address(credit),

--- a/test/proposals/gips/GIP_0.sol
+++ b/test/proposals/gips/GIP_0.sol
@@ -175,7 +175,8 @@ contract GIP_0 is Proposal {
             AuctionHouse auctionHouse = new AuctionHouse(
                 AddressLib.get("CORE"),
                 650, // midPoint = 10m50s
-                1800 // auctionDuration = 30m
+                1800, // auctionDuration = 30m
+                0 // 0% collateral offered at start
             );
 
             LendingTerm termV1 = new LendingTerm();

--- a/test/proposals/gips/GIP_0.sol
+++ b/test/proposals/gips/GIP_0.sol
@@ -222,18 +222,9 @@ contract GIP_0 is Proposal {
                 ONBOARD_TIMELOCK_DELAY
             );
             LendingTermOnboarding onboardGovernorGuild = new LendingTermOnboarding(
-                    LendingTerm.LendingTermReferences({
-                        profitManager: AddressLib.get("PROFIT_MANAGER"),
-                        guildToken: AddressLib.get("ERC20_GUILD"),
-                        auctionHouse: AddressLib.get("AUCTION_HOUSE"),
-                        creditMinter: AddressLib.get(
-                            "RATE_LIMITED_CREDIT_MINTER"
-                        ),
-                        creditToken: AddressLib.get("ERC20_GUSDC")
-                    }), /// _lendingTermReferences
-                    1, // _gaugeType
                     AddressLib.get("CORE"), // _core
                     address(onboardTimelock), // _timelock
+                    AddressLib.get("ERC20_GUILD"), // _guildToken
                     ONBOARD_GOVERNOR_GUILD_VOTING_DELAY, // initialVotingDelay
                     ONBOARD_GOVERNOR_GUILD_VOTING_PERIOD, // initialVotingPeriod
                     ONBOARD_GOVERNOR_GUILD_PROPOSAL_THRESHOLD, // initialProposalThreshold
@@ -294,7 +285,9 @@ contract GIP_0 is Proposal {
             termOnboarding.allowImplementation(_lendingTermV1, true);
 
             address termSDAI1 = termOnboarding.createTerm(
-                _lendingTermV1,
+                1, // gauge type,
+                _lendingTermV1, // implementation
+                AddressLib.get("AUCTION_HOUSE"), // auctionHouse
                 LendingTerm.LendingTermParams({
                     collateralToken: AddressLib.get("ERC20_SDAI"),
                     maxDebtPerCollateralToken: 1e18, // 1 CREDIT per SDAI collateral + no decimals correction

--- a/test/proposals/gips/GIP_0.sol
+++ b/test/proposals/gips/GIP_0.sol
@@ -477,8 +477,7 @@ contract GIP_0 is Proposal {
         // Configuration
         ProfitManager(AddressLib.get("PROFIT_MANAGER")).initializeReferences(
             AddressLib.get("ERC20_GUSDC"),
-            AddressLib.get("ERC20_GUILD"),
-            AddressLib.get("PSM_USDC")
+            AddressLib.get("ERC20_GUILD")
         );
         ProfitManager(AddressLib.get("PROFIT_MANAGER"))
             .setProfitSharingConfig(

--- a/test/proposals/gips/GIP_0.sol
+++ b/test/proposals/gips/GIP_0.sol
@@ -47,6 +47,9 @@ contract GIP_0 is Proposal {
     /// @notice maximum delegates for both credit and guild token
     uint256 internal constant MAX_DELEGATES = 10;
 
+    /// @notice delegate lockup period for CREDIT & GUILD
+    uint256 internal constant DELEGATE_LOCKUP_PERIOD = 7 days;
+
     /// @notice for each SDAI collateral, up to 1 credit can be borrowed
     uint256 internal constant MAX_SDAI_CREDIT_RATIO = 1e18;
 
@@ -501,8 +504,14 @@ contract GIP_0 is Proposal {
         GuildToken(AddressLib.get("ERC20_GUILD")).setMaxDelegates(
             MAX_DELEGATES
         );
+        GuildToken(AddressLib.get("ERC20_GUILD")).setDelegateLockupPeriod(
+            DELEGATE_LOCKUP_PERIOD
+        );
         CreditToken(AddressLib.get("ERC20_GUSDC")).setMaxDelegates(
             MAX_DELEGATES
+        );
+        CreditToken(AddressLib.get("ERC20_GUSDC")).setDelegateLockupPeriod(
+            DELEGATE_LOCKUP_PERIOD
         );
 
         // deployer renounces governor role

--- a/test/proposals/gips/GIP_0.sol
+++ b/test/proposals/gips/GIP_0.sol
@@ -335,6 +335,20 @@ contract GIP_0 is Proposal {
         );
         core.grantRole(CoreRoles.CREDIT_MINTER, AddressLib.get("PSM_USDC"));
 
+        // CREDIT_BURNER
+        core.grantRole(
+            CoreRoles.CREDIT_BURNER,
+            AddressLib.get("PROFIT_MANAGER")
+        );
+        core.grantRole(
+            CoreRoles.CREDIT_BURNER,
+            AddressLib.get("PSM_USDC")
+        );
+        core.grantRole(
+            CoreRoles.CREDIT_BURNER,
+            AddressLib.get("TERM_SDAI_1")
+        );
+
         // RATE_LIMITED_CREDIT_MINTER
         core.grantRole(
             CoreRoles.RATE_LIMITED_CREDIT_MINTER,

--- a/test/unit/governance/GuildGovernor.t.sol
+++ b/test/unit/governance/GuildGovernor.t.sol
@@ -8,6 +8,7 @@ import {MockERC20} from "@test/mock/MockERC20.sol";
 import {CoreRoles} from "@src/core/CoreRoles.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
 import {GuildGovernor} from "@src/governance/GuildGovernor.sol";
+import {IGovernorTimelock} from "@openzeppelin/contracts/governance/extensions/IGovernorTimelock.sol";
 import {GovernorCountingSimple} from "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol";
 import {GuildTimelockController} from "@src/governance/GuildTimelockController.sol";
 
@@ -80,6 +81,7 @@ contract GuildGovernorUnitTest is Test {
         assertEq(address(governor.token()), address(token));
         assertEq(governor.name(), "ECG Governor");
         assertEq(governor.version(), "1");
+        assertEq(governor.supportsInterface(type(IGovernorTimelock).interfaceId), true);
     }
 
     function testSuccessfulProposal() public {

--- a/test/unit/governance/GuildVetoGovernor.t.sol
+++ b/test/unit/governance/GuildVetoGovernor.t.sol
@@ -71,6 +71,14 @@ contract GuildVetoGovernorUnitTest is Test {
         assertEq(governor.version(), "1");
     }
 
+    function testCannotCancel() public {
+        address[] memory targets;
+        uint256[] memory values;
+        bytes[] memory calldatas;
+        vm.expectRevert("LendingTermOnboarding: cannot cancel proposals");
+        governor.cancel(targets, values, calldatas, bytes32(0));
+    }
+
     function testSuccessfulVeto() public {
         // schedule an action in the timelock
         bytes32 timelockId = _queueDummyTimelockAction(12345);

--- a/test/unit/governance/GuildVetoGovernor.t.sol
+++ b/test/unit/governance/GuildVetoGovernor.t.sol
@@ -7,6 +7,7 @@ import {MockERC20} from "@test/mock/MockERC20.sol";
 import {CoreRoles} from "@src/core/CoreRoles.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
 import {GuildVetoGovernor} from "@src/governance/GuildVetoGovernor.sol";
+import {GovernorCountingSimple} from "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol";
 import {GuildTimelockController} from "@src/governance/GuildTimelockController.sol";
 
 contract GuildVetoGovernorUnitTest is Test {
@@ -64,7 +65,7 @@ contract GuildVetoGovernorUnitTest is Test {
         assertEq(governor.COUNTING_MODE(), "support=bravo&quorum=against");
         assertEq(governor.proposalThreshold(), 0);
         assertEq(governor.votingDelay(), 0);
-        assertEq(governor.votingPeriod(), 2425847);
+        assertEq(governor.votingPeriod(), 2628000);
         assertEq(address(governor.token()), address(token));
         assertEq(governor.name(), "ECG Veto Governor");
         assertEq(governor.version(), "1");
@@ -92,7 +93,7 @@ contract GuildVetoGovernorUnitTest is Test {
         assertEq(uint256(governor.proposalSnapshot(proposalId)), block.number);
         assertEq(
             uint256(governor.proposalDeadline(proposalId)),
-            block.number + 2425847
+            block.number + 2628000
         );
 
         // cannot vote in the same block as the propose()
@@ -107,7 +108,7 @@ contract GuildVetoGovernorUnitTest is Test {
         assertEq(forVotes, 0); // nobody voted
         assertEq(abstainVotes, 0); // nobody voted
         vm.expectRevert("Governor: vote not currently active");
-        governor.castVote(proposalId, uint8(GuildVetoGovernor.VoteType.Against));
+        governor.castVote(proposalId, uint8(GovernorCountingSimple.VoteType.Against));
 
         // on next block, the vote is active
         vm.roll(block.number + 1);
@@ -118,7 +119,7 @@ contract GuildVetoGovernorUnitTest is Test {
         );
 
         // we vote and reach quorum
-        governor.castVote(proposalId, uint8(GuildVetoGovernor.VoteType.Against));
+        governor.castVote(proposalId, uint8(GovernorCountingSimple.VoteType.Against));
         assertEq(governor.hasVoted(proposalId, address(this)), true); // we have voted
         (againstVotes, forVotes, abstainVotes) = governor.proposalVotes(
             proposalId
@@ -165,10 +166,10 @@ contract GuildVetoGovernorUnitTest is Test {
             uint256(governor.state(proposalId)),
             uint256(IGovernor.ProposalState.Active)
         );
-        governor.castVote(proposalId, uint8(GuildVetoGovernor.VoteType.Against));
+        governor.castVote(proposalId, uint8(GovernorCountingSimple.VoteType.Against));
         // cannot vote twice
-        vm.expectRevert("GuildVetoGovernor: vote already cast");
-        governor.castVote(proposalId, uint8(GuildVetoGovernor.VoteType.Against));
+        vm.expectRevert("GovernorVotingSimple: vote already cast");
+        governor.castVote(proposalId, uint8(GovernorCountingSimple.VoteType.Against));
         // still Active after voting because quorum is not reached
         assertEq(
             uint256(governor.state(proposalId)),
@@ -230,7 +231,7 @@ contract GuildVetoGovernorUnitTest is Test {
         );
 
         // vote for the proposal
-        governor.castVote(proposalId, uint8(GuildVetoGovernor.VoteType.Against));
+        governor.castVote(proposalId, uint8(GovernorCountingSimple.VoteType.Against));
         assertEq(
             uint256(governor.state(proposalId)),
             uint256(IGovernor.ProposalState.Succeeded)
@@ -249,7 +250,7 @@ contract GuildVetoGovernorUnitTest is Test {
 
         // cannot vote for veto anymore
         vm.expectRevert("Governor: vote not currently active");
-        governor.castVote(proposalId, uint8(GuildVetoGovernor.VoteType.Against));
+        governor.castVote(proposalId, uint8(GovernorCountingSimple.VoteType.Against));
     }
 
     function testCanOnlyVoteAgainst() public {
@@ -268,13 +269,13 @@ contract GuildVetoGovernorUnitTest is Test {
         vm.expectRevert(
             "GuildVetoGovernor: can only vote against in veto proposals"
         );
-        governor.castVote(proposalId, uint8(GuildVetoGovernor.VoteType.For));
+        governor.castVote(proposalId, uint8(GovernorCountingSimple.VoteType.For));
 
         // cannot vote Abstain
         vm.expectRevert(
             "GuildVetoGovernor: can only vote against in veto proposals"
         );
-        governor.castVote(proposalId, uint8(GuildVetoGovernor.VoteType.Abstain));
+        governor.castVote(proposalId, uint8(GovernorCountingSimple.VoteType.Abstain));
     }
 
     function testSetQuorum() public {

--- a/test/unit/governance/LendingTermOffboarding.t.sol
+++ b/test/unit/governance/LendingTermOffboarding.t.sol
@@ -66,7 +66,7 @@ contract LendingTermOffboardingUnitTest is Test {
             address(credit),
             address(collateral)
         );
-        profitManager.initializeReferences(address(credit), address(guild), address(psm));
+        profitManager.initializeReferences(address(credit), address(guild));
         offboarder = new LendingTermOffboarding(
             address(core),
             address(guild),

--- a/test/unit/governance/LendingTermOffboarding.t.sol
+++ b/test/unit/governance/LendingTermOffboarding.t.sol
@@ -76,7 +76,8 @@ contract LendingTermOffboardingUnitTest is Test {
         auctionHouse = new AuctionHouse(
             address(core),
             650,
-            1800
+            1800,
+            0
         );
         term = LendingTerm(Clones.clone(address(new LendingTerm())));
         term.initialize(

--- a/test/unit/governance/LendingTermOffboarding.t.sol
+++ b/test/unit/governance/LendingTermOffboarding.t.sol
@@ -50,7 +50,7 @@ contract LendingTermOffboardingUnitTest is Test {
         core = new Core();
         profitManager = new ProfitManager(address(core));
         credit = new CreditToken(address(core), "name", "symbol");
-        guild = new GuildToken(address(core), address(profitManager));
+        guild = new GuildToken(address(core));
         collateral = new MockERC20();
         rlcm = new RateLimitedMinter(
             address(core), /*_core*/

--- a/test/unit/governance/LendingTermOffboarding.t.sol
+++ b/test/unit/governance/LendingTermOffboarding.t.sol
@@ -102,6 +102,9 @@ contract LendingTermOffboardingUnitTest is Test {
         // permissions
         core.grantRole(CoreRoles.GOVERNOR, governor);
         core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(term));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(profitManager));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(psm));
         core.grantRole(CoreRoles.GUILD_MINTER, address(this));
         core.grantRole(CoreRoles.GAUGE_ADD, address(this));
         core.grantRole(CoreRoles.GAUGE_REMOVE, address(this));

--- a/test/unit/governance/LendingTermOnboarding.t.sol
+++ b/test/unit/governance/LendingTermOnboarding.t.sol
@@ -296,6 +296,16 @@ contract LendingTermOnboardingUnitTest is Test {
             openingFee: 789,
             hardCap: 0 // hardCap of 0 makes no debt available
         }));
+        vm.expectRevert("LendingTermOnboarding: invalid periodic payment params");
+        onboarder.createTerm(1, address(termImplementation), address(auctionHouse), LendingTerm.LendingTermParams({
+            collateralToken: address(collateral),
+            maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
+            interestRate: _INTEREST_RATE,
+            maxDelayBetweenPartialRepay: 0, // incoherence between delay & minPercent
+            minPartialRepayPercent: 0.1e18,
+            openingFee: 789,
+            hardCap: _HARDCAP
+        }));
         vm.expectRevert("LendingTermOnboarding: unknown market");
         onboarder.createTerm(12345, address(termImplementation), address(auctionHouse), LendingTerm.LendingTermParams({
             collateralToken: address(collateral),

--- a/test/unit/governance/LendingTermOnboarding.t.sol
+++ b/test/unit/governance/LendingTermOnboarding.t.sol
@@ -387,6 +387,10 @@ contract LendingTermOnboardingUnitTest is Test {
         vm.warp(block.timestamp + 13);
         assertEq(uint8(onboarder.state(proposalId)), uint8(IGovernor.ProposalState.Active));
 
+        // cannot cancel
+        vm.expectRevert("LendingTermOnboarding: cannot cancel proposals");
+        onboarder.cancel(targets, values, calldatas, keccak256(bytes(description)));
+
         // support & check status
         vm.prank(bob);
         onboarder.castVote(proposalId, uint8(GovernorCountingSimple.VoteType.For));

--- a/test/unit/governance/LendingTermOnboarding.t.sol
+++ b/test/unit/governance/LendingTermOnboarding.t.sol
@@ -76,7 +76,8 @@ contract LendingTermOnboardingUnitTest is Test {
         auctionHouse = new AuctionHouse(
             address(core),
             650,
-            1800
+            1800,
+            0
         );
         termImplementation = new LendingTerm();
         timelock = new GuildTimelockController(

--- a/test/unit/governance/LendingTermOnboarding.t.sol
+++ b/test/unit/governance/LendingTermOnboarding.t.sol
@@ -28,7 +28,7 @@ contract LendingTermOnboardingUnitTest is Test {
     MockERC20 private collateral;
     SimplePSM private psm;
     LendingTerm private termImplementation;
-    AuctionHouse auctionHouse;
+    AuctionHouse public auctionHouse;
     RateLimitedMinter rlcm;
     GuildTimelockController private timelock;
     LendingTermOnboarding private onboarder;
@@ -352,6 +352,20 @@ contract LendingTermOnboardingUnitTest is Test {
         // cannot propose an arbitrary address (must come from factory)
         vm.expectRevert("LendingTermOnboarding: invalid term");
         onboarder.proposeOnboard(address(this));
+
+        // cannot propose if implementation has been disallowed since
+        vm.prank(governor);
+        onboarder.allowImplementation(
+            address(termImplementation),
+            false
+        );
+        vm.expectRevert("LendingTermOnboarding: invalid term");
+        onboarder.proposeOnboard(address(this));
+        vm.prank(governor);
+        onboarder.allowImplementation(
+            address(termImplementation),
+            true
+        );
 
         // cannot propose if the user doesn't have enough GUILD
         vm.expectRevert("Governor: proposer votes below proposal threshold");

--- a/test/unit/governance/LendingTermOnboarding.t.sol
+++ b/test/unit/governance/LendingTermOnboarding.t.sol
@@ -103,7 +103,7 @@ contract LendingTermOnboardingUnitTest is Test {
             creditToken: address(credit)
         }));
 
-        profitManager.initializeReferences(address(credit), address(guild), address(psm));
+        profitManager.initializeReferences(address(credit), address(guild));
 
         // permissions
         core.grantRole(CoreRoles.GOVERNOR, governor);

--- a/test/unit/governance/ProfitManager.t.sol
+++ b/test/unit/governance/ProfitManager.t.sol
@@ -15,7 +15,7 @@ import {MockLendingTerm} from "@test/mock/MockLendingTerm.sol";
 contract ProfitManagerUnitTest is Test {
     address private governor = address(1);
     Core private core;
-    ProfitManager private profitManager;
+    ProfitManager public profitManager;
     CreditToken credit;
     GuildToken guild;
     MockERC20 private pegToken;
@@ -34,12 +34,12 @@ contract ProfitManagerUnitTest is Test {
         core = new Core();
         profitManager = new ProfitManager(address(core));
         credit = new CreditToken(address(core), "name", "symbol");
-        guild = new GuildToken(address(core), address(profitManager));
+        guild = new GuildToken(address(core));
         pegToken = new MockERC20();
         pegToken.setDecimals(6);
-        gauge1 = address(new MockLendingTerm(address(core)));
-        gauge2 = address(new MockLendingTerm(address(core)));
-        gauge3 = address(new MockLendingTerm(address(core)));
+        gauge1 = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));
+        gauge2 = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));
+        gauge3 = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));
         psm = new SimplePSM(
             address(core),
             address(profitManager),

--- a/test/unit/governance/ProfitManager.t.sol
+++ b/test/unit/governance/ProfitManager.t.sol
@@ -76,8 +76,7 @@ contract ProfitManagerUnitTest is Test {
         // initialize profitManager
         assertEq(profitManager.credit(), address(0));
         assertEq(profitManager.guild(), address(0));
-        assertEq(profitManager.psm(), address(0));
-        profitManager.initializeReferences(address(credit), address(guild), address(psm));
+        profitManager.initializeReferences(address(credit), address(guild));
 
         core.renounceRole(CoreRoles.GOVERNOR, address(this));
     }
@@ -90,7 +89,6 @@ contract ProfitManagerUnitTest is Test {
         assertEq(address(profitManager.core()), address(core));
         assertEq(profitManager.credit(), address(credit));
         assertEq(profitManager.guild(), address(guild));
-        assertEq(profitManager.psm(), address(psm));
         assertEq(profitManager.surplusBuffer(), 0);
         assertEq(profitManager.creditMultiplier(), 1e18);
     }
@@ -100,14 +98,14 @@ contract ProfitManagerUnitTest is Test {
         assertEq(pm2.credit(), address(0));
         assertEq(pm2.guild(), address(0));
         vm.expectRevert("UNAUTHORIZED");
-        pm2.initializeReferences(address(credit), address(guild), address(psm));
+        pm2.initializeReferences(address(credit), address(guild));
         vm.prank(governor);
-        pm2.initializeReferences(address(credit), address(guild), address(psm));
+        pm2.initializeReferences(address(credit), address(guild));
         assertEq(pm2.credit(), address(credit));
         assertEq(pm2.guild(), address(guild));
         vm.expectRevert();
         vm.prank(governor);
-        pm2.initializeReferences(address(credit), address(guild), address(psm));
+        pm2.initializeReferences(address(credit), address(guild));
     }
 
     function testCreditMultiplier() public {

--- a/test/unit/governance/ProfitManager.t.sol
+++ b/test/unit/governance/ProfitManager.t.sol
@@ -63,6 +63,11 @@ contract ProfitManagerUnitTest is Test {
         core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
         core.grantRole(CoreRoles.GAUGE_ADD, address(this));
         core.grantRole(CoreRoles.CREDIT_MINTER, address(psm));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(gauge1));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(gauge2));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(gauge3));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(profitManager));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(psm));
 
         // non-zero CREDIT circulating (for notify gauge losses)
         credit.mint(address(this), 100e18);

--- a/test/unit/governance/ProfitManager.t.sol
+++ b/test/unit/governance/ProfitManager.t.sol
@@ -172,6 +172,13 @@ contract ProfitManagerUnitTest is Test {
         assertEq(pegToken.balanceOf(address(psm)), 50e6);
         assertEq(credit.balanceOf(address(this)), 200e18);
         assertEq(profitManager.totalIssuance(), 50e18);
+
+        // set max
+        vm.prank(governor);
+        profitManager.setMaxTotalIssuance(1000e18);
+        profitManager.notifyPnL(gauge1, 0, 950e18); // ok
+        vm.expectRevert("ProfitManager: global debt ceiling reached");
+        profitManager.notifyPnL(gauge1, 0, 1);
     }
 
     function testMinBorrow() public {
@@ -288,6 +295,22 @@ contract ProfitManagerUnitTest is Test {
         profitManager.setMinBorrow(1000e18);
 
         assertEq(profitManager.minBorrow(), 1000e18);
+    }
+
+    function testSetMaxTotalIssuance() public {
+        assertEq(profitManager.maxTotalIssuance(), 1e30);
+
+        // revert if not governor
+        vm.expectRevert("UNAUTHORIZED");
+        profitManager.setMaxTotalIssuance(1000e18);
+
+        assertEq(profitManager.maxTotalIssuance(), 1e30);
+
+        // ok
+        vm.prank(governor);
+        profitManager.setMaxTotalIssuance(1000e18);
+
+        assertEq(profitManager.maxTotalIssuance(), 1000e18);
     }
 
     function testSetGaugeWeightTolerance() public {

--- a/test/unit/loan/AuctionHouse.t.sol
+++ b/test/unit/loan/AuctionHouse.t.sol
@@ -89,6 +89,9 @@ contract AuctionHouseUnitTest is Test {
         core.grantRole(CoreRoles.GOVERNOR, governor);
         core.grantRole(CoreRoles.GUARDIAN, guardian);
         core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(term));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(profitManager));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(psm));
         core.grantRole(CoreRoles.GUILD_MINTER, address(this));
         core.grantRole(CoreRoles.GAUGE_ADD, address(this));
         core.grantRole(CoreRoles.GAUGE_REMOVE, address(this));

--- a/test/unit/loan/AuctionHouse.t.sol
+++ b/test/unit/loan/AuctionHouse.t.sol
@@ -61,7 +61,8 @@ contract AuctionHouseUnitTest is Test {
         auctionHouse = new AuctionHouse(
             address(core),
             _MIDPOINT,
-            _AUCTION_DURATION
+            _AUCTION_DURATION,
+            0 // start by offering 0% collateral
         );
         term = LendingTerm(Clones.clone(address(new LendingTerm())));
         term.initialize(
@@ -124,6 +125,7 @@ contract AuctionHouseUnitTest is Test {
         assertEq(address(auctionHouse.core()), address(core));
         assertEq(auctionHouse.midPoint(), _MIDPOINT);
         assertEq(auctionHouse.auctionDuration(), _AUCTION_DURATION);
+        assertEq(auctionHouse.startCollateralOffered(), 0);
         assertEq(auctionHouse.nAuctionsInProgress(), 0);
 
         assertEq(collateral.totalSupply(), 0);
@@ -299,6 +301,80 @@ contract AuctionHouseUnitTest is Test {
             assertEq(collateralReceived, 15e18);
             assertEq(creditAsked, 0);
         }
+    }
+
+    // getBidDetail at various steps, with 50% starting collateral offered
+    function testGetBidDetail2() public {
+        auctionHouse = new AuctionHouse(
+            address(core),
+            _MIDPOINT,
+            _AUCTION_DURATION,
+            0.5e18 // start by offering 50% collateral
+        );
+        vm.prank(governor);
+        term.setAuctionHouse(address(auctionHouse));
+        assertEq(auctionHouse.startCollateralOffered(), 0.5e18);
+
+        bytes32 loanId = _setupAndCallLoan();
+        assertEq(auctionHouse.getAuction(loanId).collateralAmount, 15e18);
+        assertEq(auctionHouse.getAuction(loanId).callDebt, 22_000e18);
+        uint256 PHASE_1_DURATION = auctionHouse.midPoint();
+        uint256 PHASE_2_DURATION = auctionHouse.auctionDuration() - auctionHouse.midPoint();
+
+        // right at the start of auction
+        {
+            (uint256 collateralReceived, uint256 creditAsked) = auctionHouse.getBidDetail(loanId);
+            assertEq(collateralReceived, 7.5e18);
+            assertEq(creditAsked, 22_000e18);
+        }
+
+        // 10% of first phase
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + PHASE_1_DURATION / 10);
+        {
+            (uint256 collateralReceived, uint256 creditAsked) = auctionHouse.getBidDetail(loanId);
+            assertEq(collateralReceived, 7.5e18 + 0.75e18);
+            assertEq(creditAsked, 22_000e18);
+        }
+
+        // 50% of first phase
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + PHASE_1_DURATION * 4 / 10);
+        {
+            (uint256 collateralReceived, uint256 creditAsked) = auctionHouse.getBidDetail(loanId);
+            assertEq(collateralReceived, 7.5e18 + 3.75e18);
+            assertEq(creditAsked, 22_000e18);
+        }
+    
+        // 90% of first phase
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + PHASE_1_DURATION * 4 / 10);
+        {
+            (uint256 collateralReceived, uint256 creditAsked) = auctionHouse.getBidDetail(loanId);
+            assertEq(collateralReceived, 7.5e18 + 6.75e18);
+            assertEq(creditAsked, 22_000e18);
+        }
+
+        // at midpoint
+        // offer all collateral, ask all debt
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + PHASE_1_DURATION / 10);
+        {
+            (uint256 collateralReceived, uint256 creditAsked) = auctionHouse.getBidDetail(loanId);
+            assertEq(collateralReceived, 15e18);
+            assertEq(creditAsked, 22_000e18);
+        }
+
+        // 10% of second phase
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + PHASE_2_DURATION / 10);
+        {
+            (uint256 collateralReceived, uint256 creditAsked) = auctionHouse.getBidDetail(loanId);
+            assertEq(collateralReceived, 15e18);
+            assertEq(creditAsked, 19_800e18);
+        }
+
+        // ...etc, startCollateralOffered only changes first phase
     }
 
     // getBidDetail fail if auction is not active

--- a/test/unit/loan/AuctionHouse.t.sol
+++ b/test/unit/loan/AuctionHouse.t.sol
@@ -83,7 +83,7 @@ contract AuctionHouseUnitTest is Test {
                 hardCap: 20_000_000e18 // 20M CREDIT
             })
         );
-        profitManager.initializeReferences(address(credit), address(guild), address(psm));
+        profitManager.initializeReferences(address(credit), address(guild));
 
         // roles
         core.grantRole(CoreRoles.GOVERNOR, governor);

--- a/test/unit/loan/AuctionHouse.t.sol
+++ b/test/unit/loan/AuctionHouse.t.sol
@@ -173,7 +173,7 @@ contract AuctionHouseUnitTest is Test {
         bytes32 loanId = _setupAndCallLoan();
 
         vm.expectRevert("AuctionHouse: invalid caller");
-        auctionHouse.startAuction(loanId, 22_000e18);
+        auctionHouse.startAuction(loanId);
     }
 
     // startAuction fail if the loan is not closed in current block
@@ -186,7 +186,7 @@ contract AuctionHouseUnitTest is Test {
         vm.warp(block.timestamp + 13);
         vm.prank(address(term));
         vm.expectRevert("AuctionHouse: loan previously called");
-        auctionHouse.startAuction(loanId, 22_000e18);
+        auctionHouse.startAuction(loanId);
     }
     
     // startAuction fail if the auction already exists
@@ -197,7 +197,7 @@ contract AuctionHouseUnitTest is Test {
         // (this would only happen due to invalid logic in the LendingTerm)
         vm.prank(address(term));
         vm.expectRevert("AuctionHouse: auction exists");
-        auctionHouse.startAuction(loanId, 22_000e18);
+        auctionHouse.startAuction(loanId);
     }
 
     // getBidDetail at various steps

--- a/test/unit/loan/AuctionHouse.t.sol
+++ b/test/unit/loan/AuctionHouse.t.sol
@@ -43,7 +43,7 @@ contract AuctionHouseUnitTest is Test {
         profitManager = new ProfitManager(address(core));
         collateral = new MockERC20();
         credit = new CreditToken(address(core), "name", "symbol");
-        guild = new GuildToken(address(core), address(profitManager));
+        guild = new GuildToken(address(core));
         rlcm = new RateLimitedMinter(
             address(core), /*_core*/
             address(credit), /*_token*/

--- a/test/unit/loan/LendingTerm.t.sol
+++ b/test/unit/loan/LendingTerm.t.sol
@@ -19,7 +19,7 @@ contract LendingTermUnitTest is Test {
     address private governor = address(1);
     address private guardian = address(2);
     Core private core;
-    ProfitManager private profitManager;
+    ProfitManager public profitManager;
     CreditToken credit;
     GuildToken guild;
     MockERC20 collateral;
@@ -45,10 +45,7 @@ contract LendingTermUnitTest is Test {
         profitManager = new ProfitManager(address(core));
         collateral = new MockERC20();
         credit = new CreditToken(address(core), "name", "symbol");
-        guild = new GuildToken(
-            address(core),
-            address(profitManager)
-        );
+        guild = new GuildToken(address(core));
         rlcm = new RateLimitedMinter(
             address(core) /*_core*/,
             address(credit) /*_token*/,

--- a/test/unit/loan/LendingTerm.t.sol
+++ b/test/unit/loan/LendingTerm.t.sol
@@ -125,6 +125,8 @@ contract LendingTermUnitTest is Test {
         assertEq(refs.auctionHouse, address(auctionHouse));
         assertEq(refs.creditMinter, address(rlcm));
         assertEq(refs.creditToken, address(credit));
+        assertEq(term.creditToken(), address(credit));
+        assertEq(term.profitManager(), address(profitManager));
 
         LendingTerm.LendingTermParams memory params = term.getParameters();
         assertEq(params.collateralToken, address(collateral));

--- a/test/unit/loan/LendingTerm.t.sol
+++ b/test/unit/loan/LendingTerm.t.sol
@@ -1252,7 +1252,7 @@ contract LendingTermUnitTest is Test {
         // all loans by 2x.
         assertEq(profitManager.creditMultiplier(), 1e18);
         vm.prank(address(term));
-        profitManager.notifyPnL(address(term), int256(-10_000e18));
+        profitManager.notifyPnL(address(term), int256(-10_000e18), 0);
         assertEq(profitManager.creditMultiplier(), 0.5e18);
 
         // active loan debt is marked up 2x
@@ -1277,7 +1277,7 @@ contract LendingTermUnitTest is Test {
         credit.mint(address(this), 100e18);
         assertEq(profitManager.creditMultiplier(), 1e18);
         vm.prank(address(term));
-        profitManager.notifyPnL(address(term), int256(-50e18));
+        profitManager.notifyPnL(address(term), int256(-50e18), 0);
         assertEq(profitManager.creditMultiplier(), 0.5e18);
         credit.burn(100e18);
 
@@ -1365,7 +1365,7 @@ contract LendingTermUnitTest is Test {
         // all loans by 2x.
         assertEq(profitManager.creditMultiplier(), 1e18);
         vm.prank(address(term));
-        profitManager.notifyPnL(address(term), int256(-10_000e18));
+        profitManager.notifyPnL(address(term), int256(-10_000e18), 0);
         assertEq(profitManager.creditMultiplier(), 0.5e18);
 
         // active loan debt is marked up 2x
@@ -1406,7 +1406,7 @@ contract LendingTermUnitTest is Test {
         // all loans by 2x.
         assertEq(profitManager.creditMultiplier(), 1e18);
         vm.prank(address(term));
-        profitManager.notifyPnL(address(term), int256(-10_000e18));
+        profitManager.notifyPnL(address(term), int256(-10_000e18), 0);
         assertEq(profitManager.creditMultiplier(), 0.5e18);
 
         // active loan debt is marked up 2x
@@ -1449,7 +1449,7 @@ contract LendingTermUnitTest is Test {
         // all loans by 2x.
         assertEq(profitManager.creditMultiplier(), 1e18);
         vm.prank(address(term));
-        profitManager.notifyPnL(address(term), int256(-10_000e18));
+        profitManager.notifyPnL(address(term), int256(-10_000e18), 0);
         assertEq(profitManager.creditMultiplier(), 0.5e18);
 
         // active loan debt is marked up 2x
@@ -1498,7 +1498,7 @@ contract LendingTermUnitTest is Test {
         assertEq(profitManager.creditMultiplier(), 1e18);
         credit.mint(address(this), 20_000e18);
         vm.prank(address(term));
-        profitManager.notifyPnL(address(term), int256(-20_000e18));
+        profitManager.notifyPnL(address(term), int256(-20_000e18), 0);
         assertEq(profitManager.creditMultiplier(), 0.5e18);
 
         // active loan debt is marked up 2x
@@ -1523,7 +1523,7 @@ contract LendingTermUnitTest is Test {
         credit.mint(address(this), 100e18);
         assertEq(profitManager.creditMultiplier(), 1e18);
         vm.prank(address(term));
-        profitManager.notifyPnL(address(term), int256(-50e18));
+        profitManager.notifyPnL(address(term), int256(-50e18), 0);
         assertEq(profitManager.creditMultiplier(), 0.5e18);
         credit.burn(100e18);
 
@@ -1554,7 +1554,7 @@ contract LendingTermUnitTest is Test {
         assertEq(profitManager.creditMultiplier(), 1e18);
         credit.mint(address(this), 20_000e18);
         vm.prank(address(term));
-        profitManager.notifyPnL(address(term), int256(-20_000e18));
+        profitManager.notifyPnL(address(term), int256(-20_000e18), 0);
         assertEq(profitManager.creditMultiplier(), 0.5e18);
 
         // active loan debt is marked up 2x

--- a/test/unit/loan/LendingTerm.t.sol
+++ b/test/unit/loan/LendingTerm.t.sol
@@ -54,7 +54,7 @@ contract LendingTermUnitTest is Test {
             type(uint128).max /*_rateLimitPerSecond*/,
             type(uint128).max /*_bufferCap*/
         );
-        auctionHouse = new AuctionHouse(address(core), 650, 1800);
+        auctionHouse = new AuctionHouse(address(core), 650, 1800, 0);
         term = LendingTerm(Clones.clone(address(new LendingTerm())));
         term.initialize(
             address(core),

--- a/test/unit/loan/LendingTerm.t.sol
+++ b/test/unit/loan/LendingTerm.t.sol
@@ -81,7 +81,7 @@ contract LendingTermUnitTest is Test {
             address(credit),
             address(collateral)
         );
-        profitManager.initializeReferences(address(credit), address(guild), address(psm));
+        profitManager.initializeReferences(address(credit), address(guild));
 
         // roles
         core.grantRole(CoreRoles.GOVERNOR, governor);

--- a/test/unit/loan/LendingTerm.t.sol
+++ b/test/unit/loan/LendingTerm.t.sol
@@ -515,8 +515,8 @@ contract LendingTermUnitTest is Test {
         uint256 interestTime
     ) public {
         // fuzz conditions
-        collateralAmount = bound(collateralAmount, 1, 1e32);
-        borrowAmount = bound(borrowAmount, 1, 1e32);
+        collateralAmount = bound(collateralAmount, 1, 1e29);
+        borrowAmount = bound(borrowAmount, 1, 1e29);
         interestTime = bound(interestTime, 1, 10 * 365 * 24 * 3600);
 
         // do not fuzz reverting conditions (below MIN_BORROW or above maxBorrow)

--- a/test/unit/loan/LendingTerm.t.sol
+++ b/test/unit/loan/LendingTerm.t.sol
@@ -128,6 +128,7 @@ contract LendingTermUnitTest is Test {
         assertEq(refs.creditToken, address(credit));
         assertEq(term.creditToken(), address(credit));
         assertEq(term.profitManager(), address(profitManager));
+        assertEq(term.auctionHouse(), address(auctionHouse));
 
         LendingTerm.LendingTermParams memory params = term.getParameters();
         assertEq(params.collateralToken, address(collateral));

--- a/test/unit/loan/LendingTerm.t.sol
+++ b/test/unit/loan/LendingTerm.t.sol
@@ -94,6 +94,10 @@ contract LendingTermUnitTest is Test {
         core.grantRole(CoreRoles.CREDIT_MINTER, address(rlcm));
         core.grantRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, address(term));
         core.grantRole(CoreRoles.GAUGE_PNL_NOTIFIER, address(term));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(term));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(profitManager));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(psm));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(this));
         core.renounceRole(CoreRoles.GOVERNOR, address(this));
 
         // add gauge and vote for it
@@ -278,6 +282,7 @@ contract LendingTermUnitTest is Test {
         vm.startPrank(governor);
         core.grantRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, address(term2));
         core.grantRole(CoreRoles.GAUGE_PNL_NOTIFIER, address(term2));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(term2));
         vm.stopPrank();
 
         // prepare
@@ -1583,6 +1588,7 @@ contract LendingTermUnitTest is Test {
         vm.startPrank(governor);
         core.grantRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, address(term2));
         core.grantRole(CoreRoles.GAUGE_PNL_NOTIFIER, address(term2));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(term2));
         vm.stopPrank();
         assertEq(term2.debtCeiling(), type(uint256).max);
 

--- a/test/unit/loan/SimplePSM.t.sol
+++ b/test/unit/loan/SimplePSM.t.sol
@@ -88,7 +88,7 @@ contract SimplePSMUnitTest is Test {
         // update creditMultiplier
         credit.mint(address(this), 100e18);
         assertEq(profitManager.creditMultiplier(), 1e18);
-        profitManager.notifyPnL(address(this), -50e18);
+        profitManager.notifyPnL(address(this), -50e18, 0);
         assertEq(profitManager.creditMultiplier(), 0.5e18);
 
         assertEq(psm.getMintAmountOut(0), 0);
@@ -107,7 +107,7 @@ contract SimplePSMUnitTest is Test {
         // update creditMultiplier
         credit.mint(address(this), 100e18);
         assertEq(profitManager.creditMultiplier(), 1e18);
-        profitManager.notifyPnL(address(this), -50e18);
+        profitManager.notifyPnL(address(this), -50e18, 0);
         assertEq(profitManager.creditMultiplier(), 0.5e18);
 
         assertEq(psm.getRedeemAmountOut(0), 0);
@@ -128,7 +128,7 @@ contract SimplePSMUnitTest is Test {
         // and will create a min/redeem round-trip error of 1 wei.
         credit.mint(address(this), 100e18);
         assertEq(profitManager.creditMultiplier(), 1e18);
-        profitManager.notifyPnL(address(this), -int256(input % 90e18 + 1)); // [0-90%] loss
+        profitManager.notifyPnL(address(this), -int256(input % 90e18 + 1), 0); // [0-90%] loss
         assertLt(profitManager.creditMultiplier(), 1.0e18 + 1);
         assertGt(profitManager.creditMultiplier(), 0.1e18 - 1);
         credit.burn(100e18);
@@ -193,7 +193,7 @@ contract SimplePSMUnitTest is Test {
         assertEq(token.balanceOf(address(psm)), 50e6);
 
         assertEq(profitManager.creditMultiplier(), 1e18);
-        profitManager.notifyPnL(address(this), -int256(25e18));
+        profitManager.notifyPnL(address(this), -int256(25e18), 0);
         assertEq(profitManager.creditMultiplier(), 0.5e18);
 
         assertEq(psm.pegTokenBalance(), 50e6);

--- a/test/unit/loan/SimplePSM.t.sol
+++ b/test/unit/loan/SimplePSM.t.sol
@@ -44,6 +44,9 @@ contract SimplePSMUnitTest is Test {
         core.grantRole(CoreRoles.GOVERNOR, governor);
         core.grantRole(CoreRoles.GUARDIAN, guardian);
         core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(psm));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(profitManager));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(this));
         core.grantRole(CoreRoles.GUILD_MINTER, address(this));
         core.grantRole(CoreRoles.GAUGE_ADD, address(this));
         core.grantRole(CoreRoles.GAUGE_REMOVE, address(this));

--- a/test/unit/loan/SimplePSM.t.sol
+++ b/test/unit/loan/SimplePSM.t.sol
@@ -38,7 +38,7 @@ contract SimplePSMUnitTest is Test {
             address(credit),
             address(token)
         );
-        profitManager.initializeReferences(address(credit), address(guild), address(psm));
+        profitManager.initializeReferences(address(credit), address(guild));
 
         // roles
         core.grantRole(CoreRoles.GOVERNOR, governor);

--- a/test/unit/loan/SimplePSM.t.sol
+++ b/test/unit/loan/SimplePSM.t.sol
@@ -16,7 +16,7 @@ contract SimplePSMUnitTest is Test {
     address private guardian = address(2);
 
     Core private core;
-    ProfitManager private profitManager;
+    ProfitManager public profitManager;
     CreditToken credit;
     GuildToken guild;
     MockERC20 token;
@@ -31,7 +31,7 @@ contract SimplePSMUnitTest is Test {
         token = new MockERC20();
         token.setDecimals(6);
         credit = new CreditToken(address(core), "name", "symbol");
-        guild = new GuildToken(address(core), address(profitManager));
+        guild = new GuildToken(address(core));
         psm = new SimplePSM(
             address(core),
             address(profitManager),

--- a/test/unit/loan/SurplusGuildMinter.t.sol
+++ b/test/unit/loan/SurplusGuildMinter.t.sol
@@ -62,6 +62,8 @@ contract SurplusGuildMinterUnitTest is Test {
         core.grantRole(CoreRoles.GOVERNOR, governor);
         core.grantRole(CoreRoles.GUARDIAN, guardian);
         core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(term));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(profitManager));
         core.grantRole(CoreRoles.GUILD_MINTER, address(this));
         core.grantRole(CoreRoles.GAUGE_ADD, address(this));
         core.grantRole(CoreRoles.GAUGE_REMOVE, address(this));

--- a/test/unit/loan/SurplusGuildMinter.t.sol
+++ b/test/unit/loan/SurplusGuildMinter.t.sol
@@ -55,7 +55,7 @@ contract SurplusGuildMinterUnitTest is Test {
             MINT_RATIO,
             REWARD_RATIO
         );
-        profitManager.initializeReferences(address(credit), address(guild), address(0));
+        profitManager.initializeReferences(address(credit), address(guild));
         term = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));
 
         // roles

--- a/test/unit/loan/SurplusGuildMinter.t.sol
+++ b/test/unit/loan/SurplusGuildMinter.t.sol
@@ -33,7 +33,7 @@ contract SurplusGuildMinterUnitTest is Test {
 
         profitManager = new ProfitManager(address(core));
         credit = new CreditToken(address(core), "name", "symbol");
-        guild = new GuildToken(address(core), address(profitManager));
+        guild = new GuildToken(address(core));
         rlgm = new RateLimitedMinter(
             address(core), /*_core*/
             address(guild), /*_token*/
@@ -52,7 +52,7 @@ contract SurplusGuildMinterUnitTest is Test {
             REWARD_RATIO
         );
         profitManager.initializeReferences(address(credit), address(guild), address(0));
-        term = address(new MockLendingTerm(address(core)));
+        term = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));
 
         // roles
         core.grantRole(CoreRoles.GOVERNOR, governor);
@@ -307,8 +307,8 @@ contract SurplusGuildMinterUnitTest is Test {
     // test with multiple users, some gauges with losses and some not
     function testMultipleUsers() public {
         // add a 2 terms with equal weight
-        address term1 = address(new MockLendingTerm(address(core)));
-        address term2 = address(new MockLendingTerm(address(core)));
+        address term1 = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));
+        address term2 = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));
         guild.addGauge(1, term1);
         guild.addGauge(1, term2);
         guild.mint(address(this), 100e18);

--- a/test/unit/loan/SurplusGuildMinter.t.sol
+++ b/test/unit/loan/SurplusGuildMinter.t.sol
@@ -26,6 +26,10 @@ contract SurplusGuildMinterUnitTest is Test {
     uint256 constant MINT_RATIO = 2e18;
     uint256 constant REWARD_RATIO = 5e18;
 
+    function creditToken() public pure returns (address) {
+        return address(12345);
+    }
+
     function setUp() public {
         vm.warp(1679067867);
         vm.roll(16848497);
@@ -141,6 +145,14 @@ contract SurplusGuildMinterUnitTest is Test {
         assertEq(stake.profitIndex, 0);
         assertEq(stake.credit, 250e18);
         assertEq(stake.guild, 500e18);
+    }
+
+    // test stake function
+    function testStakeInvalidTerm() public {
+        credit.mint(address(this), 100e18);
+        credit.approve(address(sgm), 100e18);
+        vm.expectRevert("SurplusGuildMinter: invalid term");
+        sgm.stake(address(this), 100e18);
     }
 
     // test unstake function without loss & with interests

--- a/test/unit/loan/SurplusGuildMinter.t.sol
+++ b/test/unit/loan/SurplusGuildMinter.t.sol
@@ -165,7 +165,7 @@ contract SurplusGuildMinterUnitTest is Test {
             address(0) // otherRecipient
         );
         credit.mint(address(profitManager), 35e18);
-        profitManager.notifyPnL(term, 35e18);
+        profitManager.notifyPnL(term, 35e18, 0);
         assertEq(profitManager.surplusBuffer(), 17.5e18);
         assertEq(profitManager.termSurplusBuffer(term), 150e18);
         (,, uint256 rewardsThis) = profitManager.getPendingRewards(address(this));
@@ -235,7 +235,7 @@ contract SurplusGuildMinterUnitTest is Test {
             address(0) // otherRecipient
         );
         credit.mint(address(profitManager), 35e18);
-        profitManager.notifyPnL(term, 35e18);
+        profitManager.notifyPnL(term, 35e18, 0);
         assertEq(profitManager.surplusBuffer(), 17.5e18);
         assertEq(profitManager.termSurplusBuffer(term), 150e18);
         (,, uint256 rewardsThis) = profitManager.getPendingRewards(address(this));
@@ -248,7 +248,7 @@ contract SurplusGuildMinterUnitTest is Test {
         vm.roll(block.number + 1);
 
         // loss in gauge
-        profitManager.notifyPnL(term, -27.5e18);
+        profitManager.notifyPnL(term, -27.5e18, 0);
         assertEq(profitManager.surplusBuffer(), 17.5e18 + 150e18 - 27.5e18); // 140e18
         assertEq(profitManager.termSurplusBuffer(term), 0);
 
@@ -347,8 +347,8 @@ contract SurplusGuildMinterUnitTest is Test {
             address(0) // otherRecipient
         );
         credit.mint(address(profitManager), 420e18);
-        profitManager.notifyPnL(term1, 140e18);
-        profitManager.notifyPnL(term2, 280e18);
+        profitManager.notifyPnL(term1, 140e18, 0);
+        profitManager.notifyPnL(term2, 280e18, 0);
 
         assertEq(profitManager.surplusBuffer(), 210e18);
         assertEq(profitManager.termSurplusBuffer(term1), 150e18);
@@ -359,7 +359,7 @@ contract SurplusGuildMinterUnitTest is Test {
         vm.roll(block.number + 1);
 
         // loss in term1 + slash sgm
-        profitManager.notifyPnL(term1, -20e18);
+        profitManager.notifyPnL(term1, -20e18, 0);
         assertEq(guild.balanceOf(address(sgm)), 600e18);
         guild.applyGaugeLoss(term1, address(sgm));
         assertEq(guild.balanceOf(address(sgm)), 300e18);

--- a/test/unit/rate-limits/RateLimitedCreditMinter.t.sol
+++ b/test/unit/rate-limits/RateLimitedCreditMinter.t.sol
@@ -97,21 +97,4 @@ contract RateLimitedCreditMinterUnitTest is Test {
         // can mint the replenished amount
         rlcm.mint(alice, 100);
     }
-
-    function testMintPausable() public {
-        // create/grant role
-        vm.startPrank(governor);
-        core.createRole(
-            CoreRoles.RATE_LIMITED_CREDIT_MINTER,
-            CoreRoles.GOVERNOR
-        );
-        core.grantRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, address(this));
-        vm.stopPrank();
-        vm.prank(guardian);
-        rlcm.pause();
-
-        // minting reverts because the contract is paused
-        vm.expectRevert("Pausable: paused");
-        rlcm.mint(alice, 100);
-    }
 }

--- a/test/unit/rate-limits/RateLimitedGuildMinter.t.sol
+++ b/test/unit/rate-limits/RateLimitedGuildMinter.t.sol
@@ -97,21 +97,4 @@ contract RateLimitedGuildMinterUnitTest is Test {
         // can mint the replenished amount
         rlgm.mint(alice, 100);
     }
-
-    function testMintPausable() public {
-        // create/grant role
-        vm.startPrank(governor);
-        core.createRole(
-            CoreRoles.RATE_LIMITED_GUILD_MINTER,
-            CoreRoles.GOVERNOR
-        );
-        core.grantRole(CoreRoles.RATE_LIMITED_GUILD_MINTER, address(this));
-        vm.stopPrank();
-        vm.prank(guardian);
-        rlgm.pause();
-
-        // minting reverts because the contract is paused
-        vm.expectRevert("Pausable: paused");
-        rlgm.mint(alice, 100);
-    }
 }

--- a/test/unit/tokens/CreditToken.t.sol
+++ b/test/unit/tokens/CreditToken.t.sol
@@ -209,4 +209,70 @@ contract CreditTokenUnitTest is Test {
         assertEq(token.balanceOf(alice), 4000e18);
         assertEq(token.balanceOf(bob), 2000e18);
     }
+
+    function testSetDelegateLockupPeriod() public {
+        assertEq(token.delegateLockupPeriod(), 0);
+
+        // without role, reverts
+        vm.expectRevert("UNAUTHORIZED");
+        token.setDelegateLockupPeriod(7 days);
+
+        // grant role
+        vm.startPrank(governor);
+        core.grantRole(CoreRoles.CREDIT_GOVERNANCE_PARAMETERS, address(this));
+        vm.stopPrank();
+
+        // set max delegates
+        token.setDelegateLockupPeriod(7 days);
+        assertEq(token.delegateLockupPeriod(), 7 days);
+    }
+
+    function testDelegateLockupPeriod() public {
+        // setup
+        address other = address(12345);
+        vm.startPrank(governor);
+        core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(this));
+        core.grantRole(CoreRoles.CREDIT_GOVERNANCE_PARAMETERS, address(this));
+        vm.stopPrank();
+        token.mint(address(this), 100);
+        token.setMaxDelegates(2);
+
+        // before lockup, can do movements
+        token.transfer(other, 1);
+        token.burn(1);
+        token.approve(other, 1);
+        vm.prank(other);
+        token.transferFrom(address(this), other, 1);
+        // even after delegate
+        token.incrementDelegation(address(this), 10);
+        token.transfer(other, 1);
+        token.burn(1);
+        token.approve(other, 1);
+        vm.prank(other);
+        token.transferFrom(address(this), other, 1);
+
+        // set a delegate lockup period
+        assertEq(token.delegateLockupPeriod(), 0);
+        token.setDelegateLockupPeriod(1 days);
+        assertEq(token.delegateLockupPeriod(), 1 days);
+
+        // cannot do movements anymore
+        vm.expectRevert("ERC20MultiVotes: delegate lockup period");
+        token.transfer(other, 1);
+        vm.expectRevert("ERC20MultiVotes: delegate lockup period");
+        token.burn(1);
+        token.approve(other, 1);
+        vm.prank(other);
+        vm.expectRevert("ERC20MultiVotes: delegate lockup period");
+        token.transferFrom(address(this), other, 1);
+
+        // after lockup period, can transfer again
+        vm.warp(block.timestamp + 1 days + 1);
+        token.transfer(other, 1);
+        token.burn(1);
+        token.approve(other, 1);
+        vm.prank(other);
+        token.transferFrom(address(this), other, 1);
+    }
 }

--- a/test/unit/tokens/CreditToken.t.sol
+++ b/test/unit/tokens/CreditToken.t.sol
@@ -64,6 +64,25 @@ contract CreditTokenUnitTest is Test {
         assertEq(token.totalSupply(), 100);
     }
 
+    function testBurn() public {
+        // without role, burn reverts
+        vm.expectRevert("UNAUTHORIZED");
+        token.burn(100);
+
+        // mint tokens for alice
+        vm.prank(governor);
+        core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
+        token.mint(alice, 100);
+        assertEq(token.balanceOf(alice), 100);
+
+        // burn tokens
+        vm.prank(governor);
+        core.grantRole(CoreRoles.CREDIT_BURNER, alice);
+        vm.prank(alice);
+        token.burn(60);
+        assertEq(token.balanceOf(alice), 40);
+    }
+
     function testSetMaxDelegates() public {
         assertEq(token.maxDelegates(), 0);
 

--- a/test/unit/tokens/ERC20RebaseDistributor.t.sol
+++ b/test/unit/tokens/ERC20RebaseDistributor.t.sol
@@ -569,6 +569,28 @@ contract ERC20RebaseDistributorUnitTest is Test {
 
         token.transferFrom(from, to, 0);
     }
+
+    // reach the underflow condition in nonRebasingSupply() for coverage
+    function testNonRebasingSupplyRounding() public {
+        token.mint(bobby, 1);
+        vm.prank(bobby);
+        token.enterRebase();
+
+        // distribute 1
+        token.mint(address(this), 379);
+        token.distribute(379);
+        vm.warp(block.timestamp + 64);
+
+        // distribute 2
+        token.mint(address(this), 542);
+        token.distribute(542);
+        vm.warp(block.timestamp + 5622);
+
+        assertEq(token.totalSupply(), 2);
+        assertEq(token.rebasingSupply(), 3);
+        assertEq(token.nonRebasingSupply(), 0); // return 0 to prevent underflow
+    }
+
     function testDistributeFuzz(uint256 distributionAmount, uint256[3] memory userBalances) public {
         // fuzz values in the plausibility range
         distributionAmount = bound(distributionAmount, 0, 10_000e18);

--- a/test/unit/tokens/GuildToken.t.sol
+++ b/test/unit/tokens/GuildToken.t.sol
@@ -298,7 +298,7 @@ contract GuildTokenUnitTest is Test {
 
         // revert because user doesn't have role
         vm.expectRevert("UNAUTHORIZED");
-        profitManager.notifyPnL(gauge1, 0);
+        profitManager.notifyPnL(gauge1, 0, 0);
 
         // grant roles to test contract
         vm.startPrank(governor);
@@ -307,14 +307,14 @@ contract GuildTokenUnitTest is Test {
         vm.stopPrank();
 
         // successful call & check
-        profitManager.notifyPnL(gauge1, -100);
+        profitManager.notifyPnL(gauge1, -100, 0);
         assertEq(token.lastGaugeLoss(gauge1), block.timestamp);
 
         // successful call & check
         vm.roll(block.number + 1);
         vm.warp(block.timestamp + 13);
         credit.mint(address(profitManager), 200);
-        profitManager.notifyPnL(gauge1, 200);
+        profitManager.notifyPnL(gauge1, 200, 0);
         assertEq(token.lastGaugeLoss(gauge1), block.timestamp - 13);
     }
 
@@ -349,7 +349,7 @@ contract GuildTokenUnitTest is Test {
         vm.roll(block.number + 1);
 
         // loss in gauge 1
-        profitManager.notifyPnL(gauge1, -100);
+        profitManager.notifyPnL(gauge1, -100, 0);
     }
 
     function testApplyGaugeLoss() public {
@@ -473,7 +473,7 @@ contract GuildTokenUnitTest is Test {
         _setupAliceLossInGauge1();
 
         // loss in gauge 3
-        profitManager.notifyPnL(gauge3, -100);
+        profitManager.notifyPnL(gauge3, -100, 0);
 
         // roll to next block
         vm.warp(block.timestamp + 13);

--- a/test/unit/tokens/GuildToken.t.sol
+++ b/test/unit/tokens/GuildToken.t.sol
@@ -47,6 +47,7 @@ contract GuildTokenUnitTest is Test {
 
         core.grantRole(CoreRoles.GOVERNOR, governor);
         core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(profitManager));
         core.renounceRole(CoreRoles.GOVERNOR, address(this));
 
         // labels

--- a/test/unit/tokens/GuildToken.t.sol
+++ b/test/unit/tokens/GuildToken.t.sol
@@ -40,7 +40,7 @@ contract GuildTokenUnitTest is Test {
         profitManager = new ProfitManager(address(core));
         credit = new CreditToken(address(core), "name", "symbol");
         token = new GuildToken(address(core));
-        profitManager.initializeReferences(address(credit), address(token), address(0));
+        profitManager.initializeReferences(address(credit), address(token));
         gauge1 = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));
         gauge2 = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));
         gauge3 = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));

--- a/test/unit/tokens/GuildToken.t.sol
+++ b/test/unit/tokens/GuildToken.t.sol
@@ -12,7 +12,7 @@ import {MockLendingTerm} from "@test/mock/MockLendingTerm.sol";
 contract GuildTokenUnitTest is Test {
     address private governor = address(1);
     Core private core;
-    ProfitManager private profitManager;
+    ProfitManager public profitManager;
     CreditToken credit;
     GuildToken token;
     address constant alice = address(0x616c696365);
@@ -39,11 +39,11 @@ contract GuildTokenUnitTest is Test {
         core = new Core();
         profitManager = new ProfitManager(address(core));
         credit = new CreditToken(address(core), "name", "symbol");
-        token = new GuildToken(address(core), address(profitManager));
+        token = new GuildToken(address(core));
         profitManager.initializeReferences(address(credit), address(token), address(0));
-        gauge1 = address(new MockLendingTerm(address(core)));
-        gauge2 = address(new MockLendingTerm(address(core)));
-        gauge3 = address(new MockLendingTerm(address(core)));
+        gauge1 = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));
+        gauge2 = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));
+        gauge3 = address(new MockLendingTerm(address(core), address(profitManager), address(credit)));
 
         core.grantRole(CoreRoles.GOVERNOR, governor);
         core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
@@ -116,19 +116,6 @@ contract GuildTokenUnitTest is Test {
         // set max delegates
         token.setMaxDelegates(1);
         assertEq(token.maxDelegates(), 1);
-    }
-
-    function testSetProfitManager() public {
-        assertEq(token.profitManager(), address(profitManager));
-
-        // without role, reverts
-        vm.expectRevert("UNAUTHORIZED");
-        token.setProfitManager(address(this));
-
-        // with role, can set profitManager reference
-        vm.startPrank(governor);
-        token.setProfitManager(address(this));
-        assertEq(token.profitManager(), address(this));
     }
 
     function testSetContractExceedMaxDelegates() public {


### PR DESCRIPTION
This pull-request implements code changes necessary following the findings of the C4 audit of december 2023.

Resolution of issues :

| Issue(s) | Commit(s) | Comment |
| ------------- | ------------- | ------------- |
| [685](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/685) | 06f6172bcf4b630aee0c2633e26eadfc6e4c8a19 | Readme updates (explicitly exclude fee & hook on transfer tokens) |
| [1125](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1125) | b571a8249c30a86e5614a5d0fe85e98f4d05c83a dfc5d51dd3be0b2de7ad420267c339227566542a | Prevent `cancel()` in `GuildVetoGovernor` & `LendingTermOnboarding` |
| [1147](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1147), [1141](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1141), [370](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/370) | dd167a2f5ca267299e6ba5ea6b704cde3e54c68d | Prevent re-offboard within 7 days period + add reset function |
| DM | be56983bd50d444e5d333ac514c645a2c309a43c | Add period payment coherence check in factory |
| [1170](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1170), [377](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/377) | e35f1776596e89e276afe05b941e6764b26b7c29 | Refactor `totalBorrowedCredit()` into `totalIssuance()` |
| DM | c9cedeee868f864e9e9019040dfb25edebfa8ada | Add check that `gaugeWeightTolerance` is set to `>= 1e18` |
| [292](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/292) | a7eb7db6c49f5bf47f8ffc64c04050882f7fd72f | Update `creditMultiplier` with `targetTotalSupply()` |
| DM | 246ac3e6790ec04ccdc803f86d9e0f388d060b47 | `AuctionHouse`: read `callDebt` from `LendingTerm.getLoan()` |
| [907](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/907) | a6358140e2c522141bdd8f884aa90495fe91d2c2 | Clarify comment for interest period `YEAR` = `365.25 days` |
| [333](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/333), [858](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/858), [885](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/885), [475](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/475), [708](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/708), [651](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/651), [880](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/880), [586](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/586) | 34336359727b008850850aaf106780bfd3989354 | Fix `LendingTerm.debtCeiling()` |
| [1001](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1001) | 05a6dbab1ae77191c465ccb9afa737ab079b418a | Remove `profitManager()` ref in `GuildToken` |
| [651](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/651) (2) | dded4b1f91d66477bcea588d8a77f85f255070a9 | Prevent `guild.decrementWeight()` during offboarding |
| [1211](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1211), [1194](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1194) | c2aff8712498f7f2e1fc3b6e5265817cc35217a3 | Fix `ProfitManager` rewards stealing |
| [782](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/782) | 5a4dea4893f861d3d28de7073ff5e1db0d9c2af2 | Fix `partialRepay()` on terms with 0% APR |
| [1014](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1014) | fd7a45388b5fd550632c3acdbdbde6cb2a4ce112 | Prevent `forgive()` on called loans |
| [998](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/998) | 161566cea0c60de152cfa2fbb368c8f8838ce76f | Do not set `hardCap` to `0` in `forgive()` |
| [335](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/335) | 2ed0248481c48f17305f4b9fb2b172ca7c66127a | `SimplePSM` comment + unused import + CEI |
| [1032](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1032) | 64d57406b00defc9fdb0e77262eaa3e7a7e83be7 | Prevent cross-market `SurplusGuildMinter.stake()` |
| [1164](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1164) | e4db3bd0bab553ed991ee8a2c020799e1d01ba43 | Fix use of unitialized variable in `SurplusGuildMinter.getRewards()` |
| [1110](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1110) | 7cc739ff21152afbed5d41e28b069ef3d115e121 | Fix potential DoS issue (out of gas) in `SurplusGuildMinter` |
| [152](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/152) | 091298f558aded282a4d18b9406e1f711cc2fdac | Fix infinite loop in `ERC20Gauges._decrementWeightUntilFree()` |
| [707](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/707) | 0dfdbb28e914407a0ae5994bb8cd06be3c6478a0 | Comment clarification in `ERC20MultiVotes._setMaxDelegates()` |
| [294](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/294) | 8c3d2807c10f3f8080b85bbf1e307c790d8f207e | Fix `unmintedRebaseRewards` rounding error |
| [991](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/991) | f9f360afb9d4ea8ccb68263f1e70fcba9669a34a | Simplify code & fix rebase rewards stealing by transferring to self in `ERC20RebaseDistributor` |
| [1166](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1166) | d3a386cf3b9e5c577d0cfa27b9ca326a0b4ff785 | Add `CREDIT_BURNER` role, burning credit tokens could brick a market |
| [1231](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1231) | 4edc7d1b157d0f3d3600ce3cd5d3fe56a54c0f86 | Add check in onboarding that `implementation` & `auctionHouse` are still valid |
| [1249](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1249) | 35bcc5a10f31e961caa9a8e5205004d8a5d32c0e  | Remove pausability on `RateLimitedMinter.mint()` |
| [1069](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1069) | b550458c36f9cbc3fd302ac5b62a506e4b8d4484 | Use updated `creditMultiplier` during auctions |
| [1057](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/1057) | 6bf5c98fe875a6b523a835d42de28d4a619c2b5b | Make loans above `maxDebtForCollateral` callable |
| [335](https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/335) | 5dd23a80b5898c241dc9a3ff3d40eaf7caba73c0 | Add optional lockup period after `delegate()` in `ERC20MultiVotes` |

Other minor improvements :
- 100.00% unit test coverage
- 00c60447f5401ebf88969a570dbe5b3efd670750 Add `coverage:prune` command
- 18a2f92b9d8194b4cbd3ccc8f257a66532fa255b Refactor `GuildVetoGovernor` to improve testability
- 043f534805f29e68dc37a8862f5cbe771c06f51e Whitelist of `AuctionHouse`s in onboarding
- 8eed8bf38cd252093f3de244fdf15b3a145b4c1c Refactor onboarding to support multiple markets & keep the contract a singleton
- 6bfb7105632c4541a07a5e94806af5d70a2b22ca Add `ProfitManager.maxTotalIssuance()`
- 32c422f25fe55fa2ffc9aa31cc478eb948969585 Struct packing & other gas opts in `LendingTerm` (-50k gas on `borrow()`)
- e2c61f0dce1b8a3aad8c9583f177fd27b92e538d Add `startCollateralOffered` param in `AuctionHouse`

