### PR TITLE
Split LendingTermOnboarding & LendingTermFactory

### DIFF
--- a/src/governance/LendingTermFactory.sol
+++ b/src/governance/LendingTermFactory.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
+
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {CoreRef} from "@src/core/CoreRef.sol";
+import {CoreRoles} from "@src/core/CoreRoles.sol";
+import {LendingTerm} from "@src/loan/LendingTerm.sol";
+
+/// @notice LendingTerm factory.
+contract LendingTermFactory is CoreRef {
+
+    /// @notice mapping of allowed LendingTerm implementations
+    mapping(address => bool) public implementations;
+
+    /// @notice mapping of allowed AuctionHouses
+    mapping(address => bool) public auctionHouses;
+
+    /// @notice immutable reference to the guild token
+    address public immutable guildToken;
+
+    /// @notice gaugeType of created terms
+    /// note that gaugeType 0 is not valid, so this mapping can be used
+    /// to check that a term has been created by this factory.
+    mapping(address => uint256) public gaugeTypes;
+
+    /// @notice implementations of created terms
+    mapping(address => address) public termImplementations;
+
+    /// @notice mapping of references per market (key = gaugeType = market id)
+    mapping(uint256 => MarketReferences) public marketReferences;
+    struct MarketReferences {
+        address profitManager;
+        address creditMinter;
+        address creditToken;
+    }
+
+    /// @notice emitted when a lending term implementation's "allowed" status changes
+    event ImplementationAllowChanged(
+        uint256 indexed when,
+        address indexed implementation,
+        bool allowed
+    );
+    /// @notice emitted when an auctionHouse's "allowed" status changes
+    event AuctionHouseAllowChanged(
+        uint256 indexed when,
+        address indexed auctionHouses,
+        bool allowed
+    );
+    /// @notice emitted when a term is created
+    event TermCreated(
+        uint256 indexed when,
+        uint256 indexed gaugeType,
+        address indexed term,
+        LendingTerm.LendingTermParams params
+    );
+
+    constructor(
+        address _core,
+        address _guildToken
+    )
+        CoreRef(_core)
+    {
+        guildToken = _guildToken;
+    }
+
+    /// @notice set market references for a given market id
+    function setMarketReferences(
+        uint256 gaugeType,
+        MarketReferences calldata references
+    ) external onlyCoreRole(CoreRoles.GOVERNOR) {
+        marketReferences[gaugeType] = references;
+    }
+
+    /// @notice Allow or disallow a given implemenation
+    function allowImplementation(
+        address implementation,
+        bool allowed
+    ) external onlyCoreRole(CoreRoles.GOVERNOR) {
+        implementations[implementation] = allowed;
+        emit ImplementationAllowChanged(
+            block.timestamp,
+            implementation,
+            allowed
+        );
+    }
+
+    /// @notice Allow or disallow a given auctionHouse
+    function allowAuctionHouse(
+        address auctionHouse,
+        bool allowed
+    ) external onlyCoreRole(CoreRoles.GOVERNOR) {
+        auctionHouses[auctionHouse] = allowed;
+        emit AuctionHouseAllowChanged(block.timestamp, auctionHouse, allowed);
+    }
+
+    /// @notice Create a new LendingTerm and initialize it.
+    function createTerm(
+        uint256 gaugeType,
+        address implementation,
+        address auctionHouse,
+        LendingTerm.LendingTermParams calldata params
+    ) external returns (address) {
+        require(
+            implementations[implementation],
+            "LendingTermFactory: invalid implementation"
+        );
+        require(
+            auctionHouses[auctionHouse],
+            "LendingTermFactory: invalid auctionHouse"
+        );
+        // must be an ERC20 (maybe, at least it prevents dumb input mistakes)
+        (bool success, bytes memory returned) = params.collateralToken.call(
+            abi.encodeWithSelector(IERC20.totalSupply.selector)
+        );
+        require(
+            success && returned.length == 32,
+            "LendingTermFactory: invalid collateralToken"
+        );
+
+        require(
+            params.maxDebtPerCollateralToken != 0, // must be able to mint non-zero debt
+            "LendingTermFactory: invalid maxDebtPerCollateralToken"
+        );
+
+        require(
+            params.interestRate < 1e18, // interest rate [0, 100[% APR
+            "LendingTermFactory: invalid interestRate"
+        );
+
+        require(
+            // 31557601 comes from the constant LendingTerm.YEAR() + 1
+            params.maxDelayBetweenPartialRepay < 31557601, // periodic payment every [0, 1 year]
+            "LendingTermFactory: invalid maxDelayBetweenPartialRepay"
+        );
+
+        require(
+            params.minPartialRepayPercent < 1e18, // periodic payment sizes [0, 100[%
+            "LendingTermFactory: invalid minPartialRepayPercent"
+        );
+
+        require(
+            params.openingFee <= 0.1e18, // open fee expected [0, 10]%
+            "LendingTermFactory: invalid openingFee"
+        );
+
+        require(
+            params.hardCap != 0, // non-zero hardcap
+            "LendingTermFactory: invalid hardCap"
+        );
+
+        // if one of the periodic payment parameter is used, both must be used
+        if (
+            params.minPartialRepayPercent != 0 ||
+            params.maxDelayBetweenPartialRepay != 0
+        ) {
+            require(
+                params.minPartialRepayPercent != 0 &&
+                    params.maxDelayBetweenPartialRepay != 0,
+                "LendingTermFactory: invalid periodic payment params"
+            );
+        }
+
+        // check that references for this market has been set
+        MarketReferences storage references = marketReferences[gaugeType];
+        require(
+            references.profitManager != address(0),
+            "LendingTermFactory: unknown market"
+        );
+
+        address term = Clones.clone(implementation);
+        LendingTerm(term).initialize(
+            address(core()),
+            LendingTerm.LendingTermReferences({
+                profitManager: references.profitManager,
+                guildToken: guildToken,
+                auctionHouse: auctionHouse,
+                creditMinter: references.creditMinter,
+                creditToken: references.creditToken
+            }),
+            params
+        );
+        gaugeTypes[term] = gaugeType;
+        termImplementations[term] = implementation;
+        emit TermCreated(block.timestamp, gaugeType, term, params);
+        return term;
+    }
+}

--- a/src/governance/LendingTermOnboarding.sol
+++ b/src/governance/LendingTermOnboarding.sol
@@ -1,17 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.13;
 
-import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {Governor, IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";
 
-import {Core} from "@src/core/Core.sol";
 import {CoreRoles} from "@src/core/CoreRoles.sol";
 import {GuildToken} from "@src/tokens/GuildToken.sol";
 import {LendingTerm} from "@src/loan/LendingTerm.sol";
 import {GuildGovernor} from "@src/governance/GuildGovernor.sol";
+import {LendingTermFactory} from "@src/governance/LendingTermFactory.sol";
 
 /// @notice Utils to onboard a LendingTerm. Also acts as a LendingTerm factory.
 /// This contract acts as Governor, but users cannot queue arbitrary proposals,
@@ -21,53 +19,14 @@ import {GuildGovernor} from "@src/governance/GuildGovernor.sol";
 /// Only terms that have been deployed through this factory can be onboarded.
 /// A term can be onboarded for the first time, or re-onboarded after it has been offboarded.
 contract LendingTermOnboarding is GuildGovernor {
+
     /// @notice minimum delay between proposals of onboarding of a given term
     uint256 public constant MIN_DELAY_BETWEEN_PROPOSALS = 7 days;
     /// @notice time of last proposal of a given term
     mapping(address => uint256) public lastProposal;
 
-    /// @notice mapping of allowed LendingTerm implementations
-    mapping(address => bool) public implementations;
-    /// @notice mapping of allowed AuctionHouses
-    mapping(address => bool) public auctionHouses;
-    /// @notice immutable reference to the guild token
-    address public immutable guildToken;
-
-    /// @notice gaugeType of created terms
-    /// note that gaugeType 0 is not valid, so this mapping can be used
-    /// to check that a term has been created by this factory.
-    mapping(address => uint256) public gaugeTypes;
-
-    /// @notice implementations of created terms
-    mapping(address => address) public termImplementations;
-
-    /// @notice mapping of references per market (key = gaugeType = market id)
-    mapping(uint256 => MarketReferences) public marketReferences;
-    struct MarketReferences {
-        address profitManager;
-        address creditMinter;
-        address creditToken;
-    }
-
-    /// @notice emitted when a lending term implementation's "allowed" status changes
-    event ImplementationAllowChanged(
-        uint256 indexed when,
-        address indexed implementation,
-        bool allowed
-    );
-    /// @notice emitted when an auctionHouse's "allowed" status changes
-    event AuctionHouseAllowChanged(
-        uint256 indexed when,
-        address indexed auctionHouses,
-        bool allowed
-    );
-    /// @notice emitted when a term is created
-    event TermCreated(
-        uint256 indexed when,
-        address indexed implementation,
-        address indexed term,
-        LendingTerm.LendingTermParams params
-    );
+    /// @notice factory of lending terms where terms have to come from to be onboarded
+    address public immutable factory;
 
     constructor(
         address _core,
@@ -76,7 +35,8 @@ contract LendingTermOnboarding is GuildGovernor {
         uint256 initialVotingDelay,
         uint256 initialVotingPeriod,
         uint256 initialProposalThreshold,
-        uint256 initialQuorum
+        uint256 initialQuorum,
+        address _factory
     )
         GuildGovernor(
             _core,
@@ -88,129 +48,7 @@ contract LendingTermOnboarding is GuildGovernor {
             initialQuorum
         )
     {
-        guildToken = _guildToken;
-    }
-
-    /// @notice set market references for a given market id
-    function setMarketReferences(
-        uint256 gaugeType,
-        MarketReferences calldata references
-    ) external onlyCoreRole(CoreRoles.GOVERNOR) {
-        marketReferences[gaugeType] = references;
-    }
-
-    /// @notice Allow or disallow a given implemenation
-    function allowImplementation(
-        address implementation,
-        bool allowed
-    ) external onlyCoreRole(CoreRoles.GOVERNOR) {
-        implementations[implementation] = allowed;
-        emit ImplementationAllowChanged(
-            block.timestamp,
-            implementation,
-            allowed
-        );
-    }
-
-    /// @notice Allow or disallow a given auctionHouse
-    function allowAuctionHouse(
-        address auctionHouse,
-        bool allowed
-    ) external onlyCoreRole(CoreRoles.GOVERNOR) {
-        auctionHouses[auctionHouse] = allowed;
-        emit AuctionHouseAllowChanged(block.timestamp, auctionHouse, allowed);
-    }
-
-    /// @notice Create a new LendingTerm and initialize it.
-    function createTerm(
-        uint256 gaugeType,
-        address implementation,
-        address auctionHouse,
-        LendingTerm.LendingTermParams calldata params
-    ) external returns (address) {
-        require(
-            implementations[implementation],
-            "LendingTermOnboarding: invalid implementation"
-        );
-        require(
-            auctionHouses[auctionHouse],
-            "LendingTermOnboarding: invalid auctionHouse"
-        );
-        // must be an ERC20 (maybe, at least it prevents dumb input mistakes)
-        (bool success, bytes memory returned) = params.collateralToken.call(
-            abi.encodeWithSelector(IERC20.totalSupply.selector)
-        );
-        require(
-            success && returned.length == 32,
-            "LendingTermOnboarding: invalid collateralToken"
-        );
-
-        require(
-            params.maxDebtPerCollateralToken != 0, // must be able to mint non-zero debt
-            "LendingTermOnboarding: invalid maxDebtPerCollateralToken"
-        );
-
-        require(
-            params.interestRate < 1e18, // interest rate [0, 100[% APR
-            "LendingTermOnboarding: invalid interestRate"
-        );
-
-        require(
-            // 31557601 comes from the constant LendingTerm.YEAR() + 1
-            params.maxDelayBetweenPartialRepay < 31557601, // periodic payment every [0, 1 year]
-            "LendingTermOnboarding: invalid maxDelayBetweenPartialRepay"
-        );
-
-        require(
-            params.minPartialRepayPercent < 1e18, // periodic payment sizes [0, 100[%
-            "LendingTermOnboarding: invalid minPartialRepayPercent"
-        );
-
-        require(
-            params.openingFee <= 0.1e18, // open fee expected [0, 10]%
-            "LendingTermOnboarding: invalid openingFee"
-        );
-
-        require(
-            params.hardCap != 0, // non-zero hardcap
-            "LendingTermOnboarding: invalid hardCap"
-        );
-
-        // if one of the periodic payment parameter is used, both must be used
-        if (
-            params.minPartialRepayPercent != 0 ||
-            params.maxDelayBetweenPartialRepay != 0
-        ) {
-            require(
-                params.minPartialRepayPercent != 0 &&
-                    params.maxDelayBetweenPartialRepay != 0,
-                "LendingTermOnboarding: invalid periodic payment params"
-            );
-        }
-
-        // check that references for this market has been set
-        MarketReferences storage references = marketReferences[gaugeType];
-        require(
-            references.profitManager != address(0),
-            "LendingTermOnboarding: unknown market"
-        );
-
-        address term = Clones.clone(implementation);
-        LendingTerm(term).initialize(
-            address(core()),
-            LendingTerm.LendingTermReferences({
-                profitManager: references.profitManager,
-                guildToken: guildToken,
-                auctionHouse: auctionHouse,
-                creditMinter: references.creditMinter,
-                creditToken: references.creditToken
-            }),
-            params
-        );
-        gaugeTypes[term] = gaugeType;
-        termImplementations[term] = implementation;
-        emit TermCreated(block.timestamp, implementation, term, params);
-        return term;
+        factory = _factory;
     }
 
     /// @dev override to prevent arbitrary calls to be proposed
@@ -238,10 +76,15 @@ contract LendingTermOnboarding is GuildGovernor {
         address term
     ) external whenNotPaused returns (uint256 proposalId) {
         // Check that the term has been created by this factory
-        bool validImpl = implementations[termImplementations[term]];
-        bool validAh = auctionHouses[LendingTerm(term).auctionHouse()];
+        bool validImpl = LendingTermFactory(factory).implementations(
+            LendingTermFactory(factory).termImplementations(term)
+        );
+        bool validAh = LendingTermFactory(factory).auctionHouses(
+            LendingTerm(term).auctionHouse()
+        );
+        uint256 gaugeType = LendingTermFactory(factory).gaugeTypes(term);
         require(
-            gaugeTypes[term] != 0 && validImpl && validAh,
+            gaugeType != 0 && validImpl && validAh,
             "LendingTermOnboarding: invalid term"
         );
 
@@ -257,7 +100,7 @@ contract LendingTermOnboarding is GuildGovernor {
         // and won't fail this check. This is intentional, because some terms might be offboarded
         // due to specific market conditions, and it might be desirable to re-onboard them
         // at a later date.
-        bool isGauge = GuildToken(guildToken).isGauge(term);
+        bool isGauge = GuildToken(address(token)).isGauge(term);
         require(!isGauge, "LendingTermOnboarding: active term");
 
         // Generate calldata for the proposal
@@ -285,6 +128,8 @@ contract LendingTermOnboarding is GuildGovernor {
             string memory description
         )
     {
+        uint256 gaugeType = LendingTermFactory(factory).gaugeTypes(term);
+
         targets = new address[](4);
         values = new uint256[](4);
         calldatas = new bytes[](4);
@@ -297,10 +142,10 @@ contract LendingTermOnboarding is GuildGovernor {
         );
 
         // 1st call: guild.addGauge(term)
-        targets[0] = guildToken;
+        targets[0] = address(token);
         calldatas[0] = abi.encodeWithSelector(
             GuildToken.addGauge.selector,
-            gaugeTypes[term],
+            gaugeType,
             term
         );
 

--- a/src/tokens/ERC20Gauges.sol
+++ b/src/tokens/ERC20Gauges.sol
@@ -41,8 +41,7 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
         ... Add internal _setMaxGauges(uint256) method
     - Remove public setContractExceedMaxGauges(address, bool) requiresAuth method
         ... Add internal _setCanExceedMaxGauges(address, bool) method
-    - Rename `calculateGaugeAllocation` to `calculateGaugeStoredAllocation` to make clear that it reads from stored weights.
-    - Add `calculateGaugeAllocation` helper function that reads from current weight.
+    - Remove `calculateGaugeAllocation` helper function
     - Add `isDeprecatedGauge(address)->bool` view function that returns true if gauge is deprecated.
     - Consistency: make incrementGauges return a uint112 instead of uint256
     - Import OpenZeppelin ERC20 & EnumerableSet instead of Solmate's
@@ -169,25 +168,6 @@ abstract contract ERC20Gauges is ERC20 {
     /// @notice helper function exposing the amount of weight available to allocate for a user
     function userUnusedWeight(address user) external view returns (uint256) {
         return balanceOf(user) - getUserWeight[user];
-    }
-
-    /** 
-    @notice helper function for calculating the proportion of a `quantity` allocated to a gauge
-    @param gauge the gauge to calculate allocation of
-    @param quantity a representation of a resource to be shared among all gauges
-    @return the proportion of `quantity` allocated to `gauge`. Returns 0 if gauge is not live, even if it has weight.
-    */
-    function calculateGaugeAllocation(
-        address gauge,
-        uint256 quantity
-    ) external view returns (uint256) {
-        if (_deprecatedGauges.contains(gauge)) return 0;
-
-        uint256 total = totalTypeWeight[gaugeType[gauge]];
-        if (total == 0) return 0;
-        uint256 weight = getGaugeWeight[gauge];
-
-        return (quantity * weight) / total;
     }
 
     /*///////////////////////////////////////////////////////////////

--- a/test/integration/IntegrationTestDAOFlows.sol
+++ b/test/integration/IntegrationTestDAOFlows.sol
@@ -36,7 +36,7 @@ contract IntegrationTestDAOFlows is PostProposalCheckFixture {
 
         /// new term so that onboard succeeds
         term = LendingTerm(
-            onboarder.createTerm(
+            factory.createTerm(
                 1,
                 AddressLib.get("LENDING_TERM_V1"),
                 AddressLib.get("AUCTION_HOUSE"),

--- a/test/integration/IntegrationTestOffboardingFlows.sol
+++ b/test/integration/IntegrationTestOffboardingFlows.sol
@@ -34,7 +34,7 @@ contract IntegrationTestOffboardingFlows is PostProposalCheckFixture {
 
         /// new term so that onboard succeeds
         term = LendingTerm(
-            onboarder.createTerm(
+            factory.createTerm(
                 1,
                 AddressLib.get("LENDING_TERM_V1"),
                 AddressLib.get("AUCTION_HOUSE"),

--- a/test/integration/IntegrationTestOnboardOffboard.sol
+++ b/test/integration/IntegrationTestOnboardOffboard.sol
@@ -165,7 +165,7 @@ contract IntegrationTestOnboardOffboard is PostProposalCheckFixture {
         );
 
         /// assert that term borrowable amount is 0
-        assertEq(guild.calculateGaugeAllocation(address(term), 100_000_000), 0);
+        assertEq(term.debtCeiling(), 0);
     }
 
     /// This test will pass once a nonce is added to onboarder
@@ -224,6 +224,6 @@ contract IntegrationTestOnboardOffboard is PostProposalCheckFixture {
         );
 
         /// assert that term borrowable amount is 0
-        assertEq(guild.calculateGaugeAllocation(address(term), 100_000_000), 0);
+        assertEq(term.debtCeiling(), 0);
     }
 }

--- a/test/integration/IntegrationTestOnboardOffboard.sol
+++ b/test/integration/IntegrationTestOnboardOffboard.sol
@@ -22,7 +22,7 @@ contract IntegrationTestOnboardOffboard is PostProposalCheckFixture {
     function setUp() public override {
         super.setUp();
         term = LendingTerm(
-            onboarder.createTerm(
+            factory.createTerm(
                 1,
                 AddressLib.get("LENDING_TERM_V1"),
                 AddressLib.get("AUCTION_HOUSE"),

--- a/test/integration/IntegrationTestOnboardingFlows.sol
+++ b/test/integration/IntegrationTestOnboardingFlows.sol
@@ -36,7 +36,7 @@ contract IntegrationTestOnboardingFlows is PostProposalCheckFixture {
     function testCreateNewTerm() public {
         /// new term so that onboard succeeds
         term = LendingTerm(
-            onboarder.createTerm(
+            factory.createTerm(
                 1,
                 AddressLib.get("LENDING_TERM_V1"),
                 AddressLib.get("AUCTION_HOUSE"),

--- a/test/integration/IntegrationTestVetoDAOFlows.sol
+++ b/test/integration/IntegrationTestVetoDAOFlows.sol
@@ -34,7 +34,7 @@ contract IntegrationTestVetoDAOFlows is PostProposalCheckFixture {
 
         /// new term so that onboard succeeds
         term = LendingTerm(
-            onboarder.createTerm(
+            factory.createTerm(
                 1,
                 AddressLib.get("LENDING_TERM_V1"),
                 AddressLib.get("AUCTION_HOUSE"),

--- a/test/integration/PostProposalCheckFixture.sol
+++ b/test/integration/PostProposalCheckFixture.sol
@@ -21,6 +21,7 @@ import {GuildVetoGovernor} from "@src/governance/GuildVetoGovernor.sol";
 import {RateLimitedMinter} from "@src/rate-limits/RateLimitedMinter.sol";
 import {PostProposalCheck} from "@test/integration/PostProposalCheck.sol";
 import {SurplusGuildMinter} from "@src/loan/SurplusGuildMinter.sol";
+import {LendingTermFactory} from "@src/governance/LendingTermFactory.sol";
 import {LendingTermOnboarding} from "@src/governance/LendingTermOnboarding.sol";
 import {LendingTermOffboarding} from "@src/governance/LendingTermOffboarding.sol";
 import {GuildTimelockController} from "@src/governance/GuildTimelockController.sol";
@@ -39,6 +40,7 @@ contract PostProposalCheckFixture is PostProposalCheck {
 
     /// Lending
     LendingTerm public term;
+    LendingTermFactory public factory;
     LendingTermOnboarding public onboarder;
     LendingTermOffboarding public offboarder;
 
@@ -112,6 +114,9 @@ contract PostProposalCheckFixture is PostProposalCheck {
         );
 
         /// lending terms
+        factory = LendingTermFactory(
+            AddressLib.get("LENDING_TERM_FACTORY")
+        );
         onboarder = LendingTermOnboarding(
             payable(AddressLib.get("ONBOARD_GOVERNOR_GUILD"))
         );

--- a/test/proposals/gips/GIP_0.sol
+++ b/test/proposals/gips/GIP_0.sol
@@ -18,6 +18,7 @@ import {ERC20MultiVotes} from "@src/tokens/ERC20MultiVotes.sol";
 import {GuildVetoGovernor} from "@src/governance/GuildVetoGovernor.sol";
 import {RateLimitedMinter} from "@src/rate-limits/RateLimitedMinter.sol";
 import {SurplusGuildMinter} from "@src/loan/SurplusGuildMinter.sol";
+import {LendingTermFactory} from "@src/governance/LendingTermFactory.sol";
 import {LendingTermOnboarding} from "@src/governance/LendingTermOnboarding.sol";
 import {GuildTimelockController} from "@src/governance/GuildTimelockController.sol";
 import {LendingTermOffboarding} from "@src/governance/LendingTermOffboarding.sol";
@@ -225,6 +226,10 @@ contract GIP_0 is Proposal {
                     AddressLib.get("CORE"),
                     ONBOARD_TIMELOCK_DELAY
                 );
+            LendingTermFactory termFactory = new LendingTermFactory(
+                AddressLib.get("CORE"), // _core
+                AddressLib.get("ERC20_GUILD") // _guildToken
+            );
             LendingTermOnboarding onboardGovernorGuild = new LendingTermOnboarding(
                 AddressLib.get("CORE"), // _core
                 address(onboardTimelock), // _timelock
@@ -232,7 +237,8 @@ contract GIP_0 is Proposal {
                 ONBOARD_GOVERNOR_GUILD_VOTING_DELAY, // initialVotingDelay
                 ONBOARD_GOVERNOR_GUILD_VOTING_PERIOD, // initialVotingPeriod
                 ONBOARD_GOVERNOR_GUILD_PROPOSAL_THRESHOLD, // initialProposalThreshold
-                ONBOARD_GOVERNOR_GUILD_QUORUM // initialQuorum
+                ONBOARD_GOVERNOR_GUILD_QUORUM, // initialQuorum
+                address(termFactory)
             );
             GuildVetoGovernor onboardVetoCredit = new GuildVetoGovernor(
                 AddressLib.get("CORE"),
@@ -254,6 +260,7 @@ contract GIP_0 is Proposal {
                 OFFBOARD_QUORUM // quorum
             );
 
+            AddressLib.set("LENDING_TERM_FACTORY", address(termFactory));
             AddressLib.set("DAO_GOVERNOR_GUILD", address(daoGovernorGuild));
             AddressLib.set("DAO_TIMELOCK", address(daoTimelock));
             AddressLib.set("DAO_VETO_CREDIT", address(daoVetoCredit));
@@ -270,23 +277,23 @@ contract GIP_0 is Proposal {
 
         // Terms
         {
-            LendingTermOnboarding termOnboarding = LendingTermOnboarding(
-                payable(AddressLib.get("ONBOARD_GOVERNOR_GUILD"))
+            LendingTermFactory termFactory = LendingTermFactory(
+                payable(AddressLib.get("LENDING_TERM_FACTORY"))
             );
             address _lendingTermV1 = AddressLib.get("LENDING_TERM_V1");
             address _auctionHouse = AddressLib.get("AUCTION_HOUSE");
-            termOnboarding.setMarketReferences(
+            termFactory.setMarketReferences(
                 1,
-                LendingTermOnboarding.MarketReferences({
+                LendingTermFactory.MarketReferences({
                     profitManager: AddressLib.get("PROFIT_MANAGER"),
                     creditMinter: AddressLib.get("RATE_LIMITED_CREDIT_MINTER"),
                     creditToken: AddressLib.get("ERC20_GUSDC")
                 })
             );
-            termOnboarding.allowImplementation(_lendingTermV1, true);
-            termOnboarding.allowAuctionHouse(_auctionHouse, true);
+            termFactory.allowImplementation(_lendingTermV1, true);
+            termFactory.allowAuctionHouse(_auctionHouse, true);
 
-            address termSDAI1 = termOnboarding.createTerm(
+            address termSDAI1 = termFactory.createTerm(
                 1, // gauge type,
                 _lendingTermV1, // implementation
                 _auctionHouse, // auctionHouse

--- a/test/unit/tokens/ERC20Gauges.t.sol
+++ b/test/unit/tokens/ERC20Gauges.t.sol
@@ -208,49 +208,6 @@ contract ERC20GaugesUnitTest is Test {
                         TEST USER GAUGE OPERATIONS
     //////////////////////////////////////////////////////////////*/
 
-    function testCalculateGaugeAllocation() public {
-        token.mint(address(this), 100e18);
-
-        token.setMaxGauges(3);
-        token.addGauge(1, gauge1);
-        token.addGauge(1, gauge2);
-
-        require(token.calculateGaugeAllocation(gauge1, 100e18) == 0);
-        require(token.calculateGaugeAllocation(gauge2, 100e18) == 0);
-
-        require(token.incrementGauge(gauge1, 1e18) == 1e18);
-        require(token.incrementGauge(gauge2, 1e18) == 2e18);
-
-        require(token.calculateGaugeAllocation(gauge1, 100e18) == 50e18);
-        require(token.calculateGaugeAllocation(gauge2, 100e18) == 50e18);
-
-        require(token.incrementGauge(gauge2, 2e18) == 4e18);
-
-        require(token.calculateGaugeAllocation(gauge1, 100e18) == 25e18);
-        require(token.calculateGaugeAllocation(gauge2, 100e18) == 75e18);
-
-        token.removeGauge(gauge1);
-        require(token.calculateGaugeAllocation(gauge1, 100e18) == 0);
-        require(token.calculateGaugeAllocation(gauge2, 100e18) == 100e18);
-
-        token.addGauge(2, gauge3); // 2nd gauge type
-        assertEq(token.gaugeType(gauge1), 1);
-        assertEq(token.gaugeType(gauge2), 1);
-        assertEq(token.gaugeType(gauge3), 2);
-
-        require(token.calculateGaugeAllocation(gauge1, 100e18) == 0);
-        require(token.calculateGaugeAllocation(gauge2, 100e18) == 100e18);
-        require(token.calculateGaugeAllocation(gauge3, 100e18) == 0);
-
-        require(token.incrementGauge(gauge3, 1e18) == 5e18);
-        assertEq(token.totalTypeWeight(1), 3e18);
-        assertEq(token.totalTypeWeight(2), 1e18);
-
-        require(token.calculateGaugeAllocation(gauge1, 100e18) == 0);
-        require(token.calculateGaugeAllocation(gauge2, 100e18) == 100e18);
-        require(token.calculateGaugeAllocation(gauge3, 100e18) == 100e18);
-    }
-
     function testIncrement(
         address[8] memory from,
         address[8] memory gauges,


### PR DESCRIPTION
The bytecode size of `LendingTermOnboarding` was above the limit, so I had to split out the factory logic into a separate contract.

Commit [9100492](https://github.com/volt-protocol/ethereum-credit-guild/pull/37/commits/910049299ba9732bc5a0feb65436fc3fc1135f59) fixes https://github.com/code-423n4/2023-12-ethereumcreditguild-findings/issues/308