### PR TITLE
Do not prevent burning during lockup period for guild token

### DIFF
--- a/src/tokens/GuildToken.sol
+++ b/src/tokens/GuildToken.sol
@@ -289,7 +289,9 @@ contract GuildToken is CoreRef, ERC20Burnable, ERC20Gauges, ERC20MultiVotes {
     ) internal virtual override(ERC20, ERC20Gauges, ERC20MultiVotes) {
         _decrementWeightUntilFree(from, amount);
         _decrementVotesUntilFree(from, amount);
-        _checkDelegateLockupPeriod(from);
+        // do not check delegate lockup when burning token
+        // as this can be used to make it impossible for a user to be slashed
+        // _checkDelegateLockupPeriod(from);
         ERC20._burn(from, amount);
     }
 

--- a/test/unit/tokens/GuildToken.t.sol
+++ b/test/unit/tokens/GuildToken.t.sol
@@ -272,7 +272,8 @@ contract GuildTokenUnitTest is ECGTest {
         // cannot do movements anymore
         vm.expectRevert("ERC20MultiVotes: delegate lockup period");
         token.transfer(other, 1);
-        vm.expectRevert("ERC20MultiVotes: delegate lockup period");
+        // vm.expectRevert("ERC20MultiVotes: delegate lockup period");
+        // burning can now be done during lockup period
         token.burn(1);
         token.approve(other, 1);
         vm.prank(other);


### PR DESCRIPTION
Otherwise a user can non stop redelegate/restart the lockup period to prevent slashing