### PR TITLE
July core release

### DIFF
--- a/protocol-configuration/addresses.arbitrum.json
+++ b/protocol-configuration/addresses.arbitrum.json
@@ -1514,5 +1514,17 @@
   {
     "addr": "0x2d12b58707b1c68e6e40c60a0e3ba9510f2dfe4e",
     "name": "9_ONBOARD_VETO_CREDIT"
+  },
+  {
+    "addr": "0xaf70c222a868c876e887fa1061fdeac03edf9d2b",
+    "name": "LENDING_TERM_V2"
+  },
+  {
+    "addr": "0x45af76ada2158b3914a2b6a901e2b85c44e0f27f",
+    "name": "TERM_PARAM_GOVERNOR_GUILD"
+  },
+  {
+    "addr": "0xc027f6e2710f414caadb98ca82c9d864d6cd947e",
+    "name": "REWARD_SWEEPER"
   }
 ]

--- a/src/governance/LendingTermOnboarding.sol
+++ b/src/governance/LendingTermOnboarding.sol
@@ -11,12 +11,11 @@ import {LendingTerm} from "@src/loan/LendingTerm.sol";
 import {GuildGovernor} from "@src/governance/GuildGovernor.sol";
 import {LendingTermFactory} from "@src/governance/LendingTermFactory.sol";
 
-/// @notice Utils to onboard a LendingTerm. Also acts as a LendingTerm factory.
+/// @notice Utils to onboard a LendingTerm.
 /// This contract acts as Governor, but users cannot queue arbitrary proposals,
 /// they can only queue LendingTerm onboarding proposals.
 /// When a vote is successful, the LendingTerm onboarding is queued in the Timelock,
 /// where CREDIT holders can veto the onboarding.
-/// Only terms that have been deployed through this factory can be onboarded.
 /// A term can be onboarded for the first time, or re-onboarded after it has been offboarded.
 contract LendingTermOnboarding is GuildGovernor {
     /// @notice minimum delay between proposals of onboarding of a given term
@@ -74,7 +73,9 @@ contract LendingTermOnboarding is GuildGovernor {
     function proposeOnboard(
         address term
     ) external whenNotPaused returns (uint256 proposalId) {
-        // Check that the term has been created by this factory
+        // Check that the term has been created by the factory
+        // and that the term's implementation & auctionHouse are still
+        // valid to use.
         bool validImpl = LendingTermFactory(factory).implementations(
             LendingTermFactory(factory).termImplementations(term)
         );

--- a/src/governance/LendingTermParamManager.sol
+++ b/src/governance/LendingTermParamManager.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
+
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {Governor, IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";
+
+import {GuildToken} from "@src/tokens/GuildToken.sol";
+import {GuildGovernor} from "@src/governance/GuildGovernor.sol";
+
+/// @notice Utils to update parameters of lending terms.
+/// This contract acts as Governor, but users cannot queue arbitrary proposals,
+/// they can only queue LendingTerm parameter update proposals.
+/// When a vote is successful, the param update is queued in the Timelock,
+/// where CREDIT holders can veto the change.
+contract LendingTermParamManager is GuildGovernor {
+    constructor(
+        address _core,
+        address _timelock,
+        address _guildToken,
+        uint256 initialVotingDelay,
+        uint256 initialVotingPeriod,
+        uint256 initialProposalThreshold,
+        uint256 initialQuorum
+    )
+        GuildGovernor(
+            _core,
+            _timelock,
+            _guildToken,
+            initialVotingDelay,
+            initialVotingPeriod,
+            initialProposalThreshold,
+            initialQuorum
+        )
+    {}
+
+    /// @dev override to prevent arbitrary calls to be proposed
+    function propose(
+        address[] memory /* targets*/,
+        uint256[] memory /* values*/,
+        bytes[] memory /* calldatas*/,
+        string memory /* description*/
+    ) public pure override(IGovernor, Governor) returns (uint256) {
+        revert("LendingTermParamManager: cannot propose arbitrary actions");
+    }
+
+    /// @dev override to prevent cancellation from the proposer
+    function cancel(
+        address[] memory /* targets*/,
+        uint256[] memory /* values*/,
+        bytes[] memory /* calldatas*/,
+        bytes32 /* descriptionHash*/
+    ) public pure override(IGovernor, Governor) returns (uint256) {
+        revert("LendingTermParamManager: cannot cancel proposals");
+    }
+
+    /// @notice propose an update of borrow ratio
+    function proposeSetMaxDebtPerCollateralToken(
+        address term,
+        uint256 borrowRatio
+    ) external whenNotPaused returns (uint256 proposalId) {
+        // check that the term is active
+        require(
+            GuildToken(address(token)).isGauge(term),
+            "LendingTermParamManager: inactive term"
+        );
+
+        // build proposal
+        address[] memory targets = new address[](1);
+        targets[0] = term;
+        uint256[] memory values = new uint256[](1); // [0]
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "setMaxDebtPerCollateralToken(uint256)",
+            borrowRatio
+        );
+        string memory description = string.concat(
+            "Update borrow ratio\n\n[",
+            Strings.toString(block.number),
+            "]",
+            " set maxDebtPerCollateralToken of term ",
+            Strings.toHexString(term),
+            " to ",
+            Strings.toString(borrowRatio)
+        );
+
+        // propose
+        return Governor.propose(targets, values, calldatas, description);
+    }
+
+    /// @notice propose an update of interestRate
+    function proposeSetInterestRate(
+        address term,
+        uint256 interestRate
+    ) external whenNotPaused returns (uint256 proposalId) {
+        // check that the term is active
+        require(
+            GuildToken(address(token)).isGauge(term),
+            "LendingTermParamManager: inactive term"
+        );
+
+        // build proposal
+        address[] memory targets = new address[](1);
+        targets[0] = term;
+        uint256[] memory values = new uint256[](1); // [0]
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "setInterestRate(uint256)",
+            interestRate
+        );
+        string memory description = string.concat(
+            "Update interest rate\n\n[",
+            Strings.toString(block.number),
+            "]",
+            " set interestRate of term ",
+            Strings.toHexString(term),
+            " to ",
+            Strings.toString(interestRate)
+        );
+
+        // propose
+        return Governor.propose(targets, values, calldatas, description);
+    }
+
+    /// @notice propose an update of hardCap
+    function proposeSetHardCap(
+        address term,
+        uint256 hardCap
+    ) external whenNotPaused returns (uint256 proposalId) {
+        // check that the term is active
+        require(
+            GuildToken(address(token)).isGauge(term),
+            "LendingTermParamManager: inactive term"
+        );
+
+        // build proposal
+        address[] memory targets = new address[](1);
+        targets[0] = term;
+        uint256[] memory values = new uint256[](1); // [0]
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "setHardCap(uint256)",
+            hardCap
+        );
+        string memory description = string.concat(
+            "Update hard cap\n\n[",
+            Strings.toString(block.number),
+            "]",
+            " set hardCap of term ",
+            Strings.toHexString(term),
+            " to ",
+            Strings.toString(hardCap)
+        );
+
+        // propose
+        return Governor.propose(targets, values, calldatas, description);
+    }
+}

--- a/src/governance/RewardSweeper.sol
+++ b/src/governance/RewardSweeper.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.13;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {CoreRef} from "@src/core/CoreRef.sol";
+import {CoreRoles} from "@src/core/CoreRoles.sol";
+import {GuildToken} from "@src/tokens/GuildToken.sol";
+import {LendingTerm} from "@src/loan/LendingTerm.sol";
+
+/** 
+@title RewardSweeper
+@author eswak
+@notice Allows sweeping of rewards (airdroppped tokens) from LendingTerms to an address
+        that can handle distribution.
+        Governance must grant GOVERNOR role to this contract.
+*/
+contract RewardSweeper is CoreRef {
+    /// @notice reference to GUILD token.
+    address public guild;
+
+    /// @notice address receiving swept rewards.
+    address public receiver;
+
+    constructor(address _core, address _guild, address _receiver) CoreRef(_core) {
+        guild = _guild;
+        receiver = _receiver;
+    }
+
+    /// @notice emitted when a reward token is swept.
+    event Sweep(uint256 indexed when, address indexed gauge, address indexed token, uint256 amount);
+
+    /// @notice set receiver address
+    function setReceiver(address _receiver) external onlyCoreRole(CoreRoles.GOVERNOR) {
+        receiver = _receiver;
+    }
+
+    /// @notice sweep tokens
+    function sweep(
+        address gauge,
+        address token
+    ) external {
+        require(msg.sender == receiver, "RewardSweeper: invalid sender");
+        require(GuildToken(guild).isGauge(gauge) || GuildToken(guild).isDeprecatedGauge(gauge), "RewardSweeper: invalid gauge");
+        address collateralToken = LendingTerm(gauge).collateralToken();
+        require(collateralToken != token, "RewardSweeper: invalid token");
+
+        uint256 amount = IERC20(token).balanceOf(gauge);
+        if (amount != 0) {
+            CoreRef.Call[] memory calls = new CoreRef.Call[](1);
+            calls[0] = CoreRef.Call({
+                target: token,
+                value: 0,
+                callData: abi.encodeWithSignature(
+                    "transfer(address,uint256)",
+                    receiver,
+                    amount
+                )
+            });
+            CoreRef(gauge).emergencyAction(calls);
+
+            emit Sweep(block.timestamp, gauge, token, amount);
+        }
+    }
+}

--- a/src/loan/LendingTerm.sol
+++ b/src/loan/LendingTerm.sol
@@ -162,7 +162,7 @@ contract LendingTerm is CoreRef {
         address _core,
         LendingTermReferences calldata _refs,
         bytes calldata _params
-    ) external {
+    ) public virtual {
         // can initialize only once
         assert(address(core()) == address(0));
         assert(_core != address(0));
@@ -280,7 +280,7 @@ contract LendingTerm is CoreRef {
     function _getLoanDebt(
         bytes32 loanId,
         uint256 creditMultiplier
-    ) internal view returns (uint256) {
+    ) internal virtual view returns (uint256) {
         Loan storage loan = loans[loanId];
         uint256 borrowTime = loan.borrowTime;
 
@@ -452,7 +452,7 @@ contract LendingTerm is CoreRef {
         address borrower,
         uint256 borrowAmount,
         uint256 collateralAmount
-    ) internal returns (bytes32 loanId) {
+    ) internal virtual returns (bytes32 loanId) {
         require(borrowAmount != 0, "LendingTerm: cannot borrow 0");
         require(collateralAmount != 0, "LendingTerm: cannot stake 0");
 

--- a/src/loan/LendingTermAdjustable.sol
+++ b/src/loan/LendingTermAdjustable.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
+
+import {CoreRoles} from "@src/core/CoreRoles.sol";
+import {LendingTerm} from "@src/loan/LendingTerm.sol";
+
+/// @notice Lending Term contract whose parameters can be changed :
+/// - interestRate 
+/// - maxDebtPerCollateralToken
+/// Note that interest rate is compounding between each new borrows
+/// and interest rate updates.
+contract LendingTermAdjustable is LendingTerm {
+    
+    /// @notice emitted when maxDebtPerCollateralToken is updated
+    event SetMaxDebtPerCollateralToken(uint256 indexed when, uint256 value);
+    /// @notice emitted when interestRate is updated
+    event SetInterestRate(uint256 indexed when, uint256 value);
+
+    struct InterestIndex {
+        uint48 lastUpdate;
+        uint208 lastValue;
+    }
+    /// @notice internal interest index
+    InterestIndex internal __interestIndex = InterestIndex({
+        lastUpdate: uint48(block.timestamp),
+        lastValue: uint208(1e18)
+    });
+
+    /// @notice loan's interest rate index on open
+    mapping(bytes32 => uint256) internal loanOpenInterestIndex;
+
+    /// @notice returns the current interest index
+    function _interestIndex() internal view returns (uint256) {
+        InterestIndex memory _interestIndex = __interestIndex;
+        uint256 elapsed = block.timestamp - _interestIndex.lastUpdate;
+        uint256 increment = (_interestIndex.lastValue *
+            params.interestRate *
+            (elapsed)) /
+            YEAR /
+            1e18;
+        return _interestIndex.lastValue + increment;
+    }
+
+    /// @notice checkpoints the interest index.
+    /// Should be called every time there is an interest rate change.
+    function _checkpointInterestIndex() internal {
+        uint256 idx = _interestIndex();
+        if (idx == 0) {
+            // for first-ever checkpoint, set value to 1e18
+            idx = 1e18;
+        }
+        __interestIndex = InterestIndex({
+            lastUpdate: uint48(block.timestamp),
+            lastValue: uint208(idx)
+        });
+    }
+
+    // override to checkpoint interestIndex & emit additional events
+    function initialize(
+        address _core,
+        LendingTermReferences calldata _refs,
+        bytes calldata _params
+    ) public override {
+        super.initialize(_core, _refs, _params);
+        _checkpointInterestIndex();
+        emit SetMaxDebtPerCollateralToken(block.timestamp, params.maxDebtPerCollateralToken);
+        emit SetInterestRate(block.timestamp, params.interestRate);
+    }
+
+    // override to save interestIndex at time of loan open
+    function _borrow(
+        address payer,
+        address borrower,
+        uint256 borrowAmount,
+        uint256 collateralAmount
+    ) internal override returns (bytes32) {
+        bytes32 loanId = super._borrow(payer, borrower, borrowAmount, collateralAmount);
+        _checkpointInterestIndex();
+        loanOpenInterestIndex[loanId] = _interestIndex();
+        return loanId;
+    }
+
+    // override to use interestIndex instead of time since opening + interestRate
+    // when computing the interest owed by an open loan.
+    function _getLoanDebt(
+        bytes32 loanId,
+        uint256 creditMultiplier
+    ) internal override view returns (uint256) {
+        Loan storage loan = loans[loanId];
+        uint256 borrowTime = loan.borrowTime;
+
+        if (borrowTime == 0) {
+            return 0;
+        }
+
+        if (loan.closeTime != 0) {
+            return 0;
+        }
+
+        if (loan.callTime != 0) {
+            return loan.callDebt;
+        }
+
+        // compute interest owed
+        uint256 borrowAmount = loan.borrowAmount;
+        uint256 currentIndex = _interestIndex();
+        uint256 openIndex = loanOpenInterestIndex[loanId];
+        uint256 loanDebt = (currentIndex * borrowAmount) / openIndex;
+        uint256 _openingFee = params.openingFee;
+        if (_openingFee != 0) {
+            loanDebt += (borrowAmount * _openingFee) / 1e18;
+        }
+        loanDebt = (loanDebt * loan.borrowCreditMultiplier) / creditMultiplier;
+
+        return loanDebt;
+    }
+
+    /// @notice set the maxDebtPerCollateralToken.
+    /// lowering this value might make some open loans callable.
+    function setMaxDebtPerCollateralToken(
+        uint256 _newValue
+    ) external onlyCoreRole(CoreRoles.GOVERNOR) {
+        params.maxDebtPerCollateralToken = _newValue;
+        emit SetMaxDebtPerCollateralToken(block.timestamp, _newValue);
+    }
+
+    /// @notice set the interestRate.
+    /// checkpointing should only apply the new interest rate on loans
+    /// starting from now, and not retroactively apply to open loans since
+    /// they have been opened.
+    function setInterestRate(
+        uint256 _newValue
+    ) external onlyCoreRole(CoreRoles.GOVERNOR) {
+        _checkpointInterestIndex();
+        params.interestRate = _newValue;
+        emit SetInterestRate(block.timestamp, _newValue);
+    }
+}

--- a/src/loan/LendingTermAdjustable.sol
+++ b/src/loan/LendingTermAdjustable.sol
@@ -30,7 +30,7 @@ contract LendingTermAdjustable is LendingTerm {
     mapping(bytes32 => uint256) internal loanOpenInterestIndex;
 
     /// @notice returns the current interest index
-    function _interestIndex() internal view returns (uint256) {
+    function _getCurrentInterestIndex() internal view returns (uint256) {
         InterestIndex memory _interestIndex = __interestIndex;
         uint256 elapsed = block.timestamp - _interestIndex.lastUpdate;
         uint256 increment = (_interestIndex.lastValue *
@@ -44,7 +44,7 @@ contract LendingTermAdjustable is LendingTerm {
     /// @notice checkpoints the interest index.
     /// Should be called every time there is an interest rate change.
     function _checkpointInterestIndex() internal {
-        uint256 idx = _interestIndex();
+        uint256 idx = _getCurrentInterestIndex();
         if (idx == 0) {
             // for first-ever checkpoint, set value to 1e18
             idx = 1e18;
@@ -76,7 +76,7 @@ contract LendingTermAdjustable is LendingTerm {
     ) internal override returns (bytes32) {
         bytes32 loanId = super._borrow(payer, borrower, borrowAmount, collateralAmount);
         _checkpointInterestIndex();
-        loanOpenInterestIndex[loanId] = _interestIndex();
+        loanOpenInterestIndex[loanId] = _getCurrentInterestIndex();
         return loanId;
     }
 
@@ -103,7 +103,7 @@ contract LendingTermAdjustable is LendingTerm {
 
         // compute interest owed
         uint256 borrowAmount = loan.borrowAmount;
-        uint256 currentIndex = _interestIndex();
+        uint256 currentIndex = _getCurrentInterestIndex();
         uint256 openIndex = loanOpenInterestIndex[loanId];
         uint256 loanDebt = (currentIndex * borrowAmount) / openIndex;
         uint256 _openingFee = params.openingFee;

--- a/test/proposals/gips/Arbitrum_12_AdjustableLendingTerm.sol
+++ b/test/proposals/gips/Arbitrum_12_AdjustableLendingTerm.sol
@@ -1,0 +1,96 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.13;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+import {Core} from "@src/core/Core.sol";
+import {CoreRoles} from "@src/core/CoreRoles.sol";
+import {RewardSweeper} from "@src/governance/RewardSweeper.sol";
+import {GovernorProposal} from "@test/proposals/proposalTypes/GovernorProposal.sol";
+import {LendingTermAdjustable} from "@src/loan/LendingTermAdjustable.sol";
+import {LendingTermOnboarding} from "@src/governance/LendingTermOnboarding.sol";
+import {LendingTermParamManager} from "@src/governance/LendingTermParamManager.sol";
+
+contract Arbitrum_12_AdjustableLendingTerm is GovernorProposal {
+    function name() public view virtual returns (string memory) {
+        return "Enable adjustable lending term & reward sweeper";
+    }
+
+    constructor() {
+        require(
+            block.chainid == 42161,
+            "Arbitrum_12_AdjustableLendingTerm: wrong chain id"
+        );
+    }
+
+    function deploy() public virtual {
+        // LendingTermAdjustable
+        LendingTermAdjustable termV2 = new LendingTermAdjustable();
+        setAddr("LENDING_TERM_V2", address(termV2));
+
+        // LendingTermParamManager
+        LendingTermOnboarding onboarder = LendingTermOnboarding(payable(getAddr("ONBOARD_GOVERNOR_GUILD")));
+        LendingTermParamManager paramMgr = new LendingTermParamManager(
+            getAddr("CORE"), // _core
+            getAddr("ONBOARD_TIMELOCK"), // _timelock
+            getAddr("ERC20_GUILD"), // _guildToken
+            onboarder.votingDelay(), // initialVotingDelay
+            onboarder.votingPeriod(), // initialVotingPeriod
+            onboarder.proposalThreshold(), // initialProposalThreshold
+            onboarder.quorum(0) // initialQuorum
+        );
+        setAddr("TERM_PARAM_GOVERNOR_GUILD", address(paramMgr));
+
+        // RewardSweeper
+        RewardSweeper sweeper = new RewardSweeper(
+            getAddr("CORE"),
+            getAddr("ERC20_GUILD"),
+            getAddr("TEAM_MULTISIG")
+        );
+        setAddr("REWARD_SWEEPER", address(sweeper));
+    }
+
+    function afterDeploy(address/* deployer*/) public pure virtual {}
+
+    function run(address /* deployer*/) public virtual {
+        _addStep(
+            getAddr("LENDING_TERM_FACTORY"),
+            abi.encodeWithSignature(
+                "allowImplementation(address,boolean)",
+                getAddr("LENDING_TERM_V2"),
+                true
+            ),
+            "Enable new LENDING_TERM_V2 implementation in factory (adjustable interest rate, borrow ratio, and hardCap)"
+        );
+        _addStep(
+            getAddr("CORE"),
+            abi.encodeWithSignature(
+                "grandRole(bytes32,address)",
+                CoreRoles.GOVERNOR,
+                getAddr("TERM_PARAM_GOVERNOR_GUILD")
+            ),
+            "Grant GOVERNOR role to TERM_PARAM_GOVERNOR_GUILD"
+        );
+        _addStep(
+            getAddr("CORE"),
+            abi.encodeWithSignature(
+                "grandRole(bytes32,address)",
+                CoreRoles.GOVERNOR,
+                getAddr("TERM_PARAM_GOVERNOR_GUILD")
+            ),
+            "Grant GOVERNOR role to REWARD_SWEEPER"
+        );
+
+        // Propose to the DAO
+        address governor = getAddr("DAO_GOVERNOR_GUILD");
+        address proposer = getAddr("TEAM_MULTISIG");
+        address voter = getAddr("TEAM_MULTISIG");
+        DEBUG = true;
+        _simulateGovernorSteps(name(), governor, proposer, voter);
+    }
+
+    function teardown(address deployer) public pure virtual {}
+
+    function validate(address deployer) public pure virtual {}
+}

--- a/test/unit/governance/LendingTermParamManager.t.sol
+++ b/test/unit/governance/LendingTermParamManager.t.sol
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.13;
+
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {Governor, IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";
+import {GovernorCountingSimple} from "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol";
+
+import {ECGTest} from "@test/ECGTest.sol";
+import {Core} from "@src/core/Core.sol";
+import {CoreRoles} from "@src/core/CoreRoles.sol";
+import {MockERC20} from "@test/mock/MockERC20.sol";
+import {SimplePSM} from "@src/loan/SimplePSM.sol";
+import {GuildToken} from "@src/tokens/GuildToken.sol";
+import {CreditToken} from "@src/tokens/CreditToken.sol";
+import {LendingTerm} from "@src/loan/LendingTerm.sol";
+import {AuctionHouse} from "@src/loan/AuctionHouse.sol";
+import {ProfitManager} from "@src/governance/ProfitManager.sol";
+import {RateLimitedMinter} from "@src/rate-limits/RateLimitedMinter.sol";
+import {LendingTermFactory} from "@src/governance/LendingTermFactory.sol";
+import {LendingTermAdjustable} from "@src/loan/LendingTermAdjustable.sol";
+import {LendingTermParamManager} from "@src/governance/LendingTermParamManager.sol";
+import {GuildTimelockController} from "@src/governance/GuildTimelockController.sol";
+
+contract LendingTermParamManagerUnitTest is ECGTest {
+    address private governor = address(1);
+    address private guardian = address(2);
+    Core private core;
+    ProfitManager private profitManager;
+    GuildToken private guild;
+    CreditToken private credit;
+    MockERC20 private collateral;
+    SimplePSM private psm;
+    LendingTermAdjustable private termImplementation;
+    LendingTermAdjustable private term;
+    AuctionHouse public auctionHouse;
+    RateLimitedMinter rlcm;
+    GuildTimelockController private timelock;
+    LendingTermFactory private factory;
+    LendingTermParamManager private paramMgr;
+    address private constant alice = address(0x616c696365);
+    address private constant bob = address(0xB0B);
+
+    // GuildTimelockController params
+    uint256 private constant _TIMELOCK_MIN_DELAY = 3600; // 1h
+
+    // LendingTerm params
+    uint256 private constant _CREDIT_PER_COLLATERAL_TOKEN = 1e18; // 1:1, same decimals
+    uint256 private constant _INTEREST_RATE = 0.05e18; // 5% APR
+    uint256 private constant _HARDCAP = 1_000_000e18;
+
+    // LendingTermParamManager params
+    uint256 private constant _VOTING_DELAY = 0;
+    uint256 private constant _VOTING_PERIOD = 100_000; // ~14 days
+    uint256 private constant _PROPOSAL_THRESHOLD = 2_500_000e18;
+    uint256 private constant _QUORUM = 20_000_000e18;
+
+    function setUp() public {
+        vm.warp(1679067867);
+        vm.roll(16848497);
+
+        // deploy
+        core = new Core();
+        profitManager = new ProfitManager(address(core));
+        credit = new CreditToken(address(core), "name", "symbol");
+        guild = new GuildToken(address(core));
+        collateral = new MockERC20();
+        rlcm = new RateLimitedMinter(
+            address(core) /*_core*/,
+            address(credit) /*_token*/,
+            CoreRoles.RATE_LIMITED_CREDIT_MINTER /*_role*/,
+            type(uint256).max /*_maxRateLimitPerSecond*/,
+            type(uint128).max /*_rateLimitPerSecond*/,
+            type(uint128).max /*_bufferCap*/
+        );
+        psm = new SimplePSM(
+            address(core),
+            address(profitManager),
+            address(credit),
+            address(collateral)
+        );
+        auctionHouse = new AuctionHouse(address(core), 650, 1800, 0);
+        termImplementation = new LendingTermAdjustable();
+        timelock = new GuildTimelockController(
+            address(core),
+            _TIMELOCK_MIN_DELAY
+        );
+        factory = new LendingTermFactory(address(core), address(guild));
+        paramMgr = new LendingTermParamManager(
+            address(core), // _core
+            address(timelock), // _timelock
+            address(guild), // _guildToken
+            _VOTING_DELAY, // initialVotingDelay
+            _VOTING_PERIOD, // initialVotingPeriod
+            _PROPOSAL_THRESHOLD, // initialProposalThreshold
+            _QUORUM // initialQuorum
+        );
+        factory.allowImplementation(address(termImplementation), true);
+        factory.allowAuctionHouse(address(auctionHouse), true);
+        factory.setMarketReferences(
+            1,
+            LendingTermFactory.MarketReferences({
+                profitManager: address(profitManager),
+                creditMinter: address(rlcm),
+                creditToken: address(credit),
+                psm: address(psm)
+            })
+        );
+
+        profitManager.initializeReferences(address(credit), address(guild));
+
+        // permissions
+        core.grantRole(CoreRoles.GOVERNOR, governor);
+        core.grantRole(CoreRoles.GUARDIAN, guardian);
+        core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
+        core.grantRole(CoreRoles.GUILD_MINTER, address(this));
+        core.grantRole(CoreRoles.GAUGE_ADD, address(this));
+        core.grantRole(CoreRoles.GAUGE_REMOVE, address(this));
+        core.grantRole(CoreRoles.GAUGE_PARAMETERS, address(this));
+        core.grantRole(CoreRoles.GUILD_GOVERNANCE_PARAMETERS, address(this));
+        core.grantRole(CoreRoles.CREDIT_MINTER, address(rlcm));
+        core.grantRole(CoreRoles.GOVERNOR, address(timelock));
+        core.grantRole(CoreRoles.GAUGE_ADD, address(timelock));
+        core.grantRole(CoreRoles.TIMELOCK_EXECUTOR, address(0));
+        core.grantRole(CoreRoles.TIMELOCK_PROPOSER, address(paramMgr));
+        core.renounceRole(CoreRoles.GOVERNOR, address(this));
+
+        // allow GUILD gauge votes & delegations
+        guild.setMaxGauges(10);
+        guild.setMaxDelegates(10);
+
+        // create one term
+        term = LendingTermAdjustable(
+            factory.createTerm(
+                1,
+                address(termImplementation),
+                address(auctionHouse),
+                abi.encode(
+                    LendingTerm.LendingTermParams({
+                        collateralToken: address(collateral),
+                        maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
+                        interestRate: _INTEREST_RATE,
+                        maxDelayBetweenPartialRepay: 123,
+                        minPartialRepayPercent: 456,
+                        openingFee: 789,
+                        hardCap: _HARDCAP
+                    })
+                )
+            )
+        );
+        guild.addGauge(1, address(term));
+
+        // labels
+        vm.label(address(this), "test");
+        vm.label(address(core), "core");
+        vm.label(address(profitManager), "profitManager");
+        vm.label(address(guild), "guild");
+        vm.label(address(credit), "credit");
+        vm.label(address(rlcm), "rlcm");
+        vm.label(address(timelock), "timelock");
+        vm.label(address(auctionHouse), "auctionHouse");
+        vm.label(address(termImplementation), "termImplementation");
+        vm.label(address(paramMgr), "paramMgr");
+        vm.label(address(term), "term");
+        vm.label(alice, "alice");
+        vm.label(bob, "bob");
+    }
+
+    function testInitialState() public {
+        assertEq(factory.implementations(address(termImplementation)), true);
+
+        assertEq(paramMgr.timelock(), address(timelock));
+        assertEq(paramMgr.votingDelay(), _VOTING_DELAY);
+        assertEq(paramMgr.votingPeriod(), _VOTING_PERIOD);
+        assertEq(paramMgr.proposalThreshold(), _PROPOSAL_THRESHOLD);
+        assertEq(paramMgr.quorum(0), _QUORUM);
+        assertEq(paramMgr.COUNTING_MODE(), "support=bravo&quorum=for,abstain");
+        assertEq(address(paramMgr.token()), address(guild));
+        assertEq(paramMgr.name(), "ECG Governor");
+        assertEq(paramMgr.version(), "1");
+
+        assertEq(term.getParameters().maxDebtPerCollateralToken, _CREDIT_PER_COLLATERAL_TOKEN);
+        assertEq(term.getParameters().interestRate, _INTEREST_RATE);
+        assertEq(term.getParameters().hardCap, _HARDCAP);
+    }
+
+    function testProposeArbitraryCallsReverts() public {
+        address[] memory targets = new address[](1);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory payloads = new bytes[](1);
+        vm.expectRevert(
+            "LendingTermParamManager: cannot propose arbitrary actions"
+        );
+        paramMgr.propose(targets, values, payloads, "test");
+    }
+
+    function testProposePausable() public {
+        // pause
+        vm.prank(guardian);
+        paramMgr.pause();
+
+        // propose
+        vm.startPrank(alice);
+        vm.expectRevert("Pausable: paused");
+        paramMgr.proposeSetHardCap(address(term), 123);
+        vm.expectRevert("Pausable: paused");
+        paramMgr.proposeSetInterestRate(address(term), 123);
+        vm.expectRevert("Pausable: paused");
+        paramMgr.proposeSetMaxDebtPerCollateralToken(address(term), 123);
+    }
+
+    function testProposeSetHardCap() public {
+        uint256 hardCap = 123456789;
+
+        // cannot propose if the user doesn't have enough GUILD
+        vm.expectRevert("Governor: proposer votes below proposal threshold");
+        paramMgr.proposeSetHardCap(address(term), hardCap);
+
+        // mint GUILD & self delegate
+        guild.mint(alice, _PROPOSAL_THRESHOLD);
+        guild.mint(bob, _QUORUM);
+        vm.prank(alice);
+        guild.delegate(alice);
+        vm.prank(bob);
+        guild.incrementDelegation(bob, _QUORUM);
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+
+        // propose
+        vm.prank(alice);
+        uint256 proposalId = paramMgr.proposeSetHardCap(address(term), hardCap);
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(term);
+        uint256[] memory values = new uint256[](1); // [0]
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "setHardCap(uint256)",
+            hardCap
+        );
+        string memory description = string.concat(
+            "Update hard cap\n\n[",
+            Strings.toString(block.number),
+            "]",
+            " set hardCap of term ",
+            Strings.toHexString(address(term)),
+            " to ",
+            Strings.toString(hardCap)
+        );
+
+        // check proposal creation
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Pending)
+        );
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Active)
+        );
+
+        // cannot cancel
+        vm.expectRevert("LendingTermParamManager: cannot cancel proposals");
+        paramMgr.cancel(
+            targets,
+            values,
+            calldatas,
+            keccak256(bytes(description))
+        );
+
+        // support & check status
+        vm.prank(bob);
+        paramMgr.castVote(
+            proposalId,
+            uint8(GovernorCountingSimple.VoteType.For)
+        );
+        vm.roll(block.number + _VOTING_PERIOD + 1);
+        vm.warp(block.timestamp + 13);
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Succeeded)
+        );
+
+        // queue
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+        paramMgr.queue(
+            targets,
+            values,
+            calldatas,
+            keccak256(bytes(description))
+        );
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Queued)
+        );
+
+        // execute
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + _TIMELOCK_MIN_DELAY + 13);
+        paramMgr.execute(
+            targets,
+            values,
+            calldatas,
+            keccak256(bytes(description))
+        );
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Executed)
+        );
+
+        // check execution
+        assertEq(term.getParameters().hardCap, hardCap);
+    }
+
+    function testProposeSetInterestRate() public {
+        uint256 interestRate = 123456789;
+
+        // cannot propose if the user doesn't have enough GUILD
+        vm.expectRevert("Governor: proposer votes below proposal threshold");
+        paramMgr.proposeSetInterestRate(address(term), interestRate);
+
+        // mint GUILD & self delegate
+        guild.mint(alice, _PROPOSAL_THRESHOLD);
+        guild.mint(bob, _QUORUM);
+        vm.prank(alice);
+        guild.delegate(alice);
+        vm.prank(bob);
+        guild.incrementDelegation(bob, _QUORUM);
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+
+        // propose
+        vm.prank(alice);
+        uint256 proposalId = paramMgr.proposeSetInterestRate(address(term), interestRate);
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(term);
+        uint256[] memory values = new uint256[](1); // [0]
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "setInterestRate(uint256)",
+            interestRate
+        );
+        string memory description = string.concat(
+            "Update interest rate\n\n[",
+            Strings.toString(block.number),
+            "]",
+            " set interestRate of term ",
+            Strings.toHexString(address(term)),
+            " to ",
+            Strings.toString(interestRate)
+        );
+
+        // check proposal creation
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Pending)
+        );
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Active)
+        );
+
+        // cannot cancel
+        vm.expectRevert("LendingTermParamManager: cannot cancel proposals");
+        paramMgr.cancel(
+            targets,
+            values,
+            calldatas,
+            keccak256(bytes(description))
+        );
+
+        // support & check status
+        vm.prank(bob);
+        paramMgr.castVote(
+            proposalId,
+            uint8(GovernorCountingSimple.VoteType.For)
+        );
+        vm.roll(block.number + _VOTING_PERIOD + 1);
+        vm.warp(block.timestamp + 13);
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Succeeded)
+        );
+
+        // queue
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+        paramMgr.queue(
+            targets,
+            values,
+            calldatas,
+            keccak256(bytes(description))
+        );
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Queued)
+        );
+
+        // execute
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + _TIMELOCK_MIN_DELAY + 13);
+        paramMgr.execute(
+            targets,
+            values,
+            calldatas,
+            keccak256(bytes(description))
+        );
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Executed)
+        );
+
+        // check execution
+        assertEq(term.getParameters().interestRate, interestRate);
+    }
+
+    function testProposeSetMaxDebtPerCollateralToken() public {
+        uint256 maxDebtPerCollateralToken = 123456789;
+
+        // cannot propose if the user doesn't have enough GUILD
+        vm.expectRevert("Governor: proposer votes below proposal threshold");
+        paramMgr.proposeSetMaxDebtPerCollateralToken(address(term), maxDebtPerCollateralToken);
+
+        // mint GUILD & self delegate
+        guild.mint(alice, _PROPOSAL_THRESHOLD);
+        guild.mint(bob, _QUORUM);
+        vm.prank(alice);
+        guild.delegate(alice);
+        vm.prank(bob);
+        guild.incrementDelegation(bob, _QUORUM);
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+
+        // propose
+        vm.prank(alice);
+        uint256 proposalId = paramMgr.proposeSetMaxDebtPerCollateralToken(address(term), maxDebtPerCollateralToken);
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(term);
+        uint256[] memory values = new uint256[](1); // [0]
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSignature(
+            "setMaxDebtPerCollateralToken(uint256)",
+            maxDebtPerCollateralToken
+        );
+        string memory description = string.concat(
+            "Update borrow ratio\n\n[",
+            Strings.toString(block.number),
+            "]",
+            " set maxDebtPerCollateralToken of term ",
+            Strings.toHexString(address(term)),
+            " to ",
+            Strings.toString(maxDebtPerCollateralToken)
+        );
+
+        // check proposal creation
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Pending)
+        );
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Active)
+        );
+
+        // cannot cancel
+        vm.expectRevert("LendingTermParamManager: cannot cancel proposals");
+        paramMgr.cancel(
+            targets,
+            values,
+            calldatas,
+            keccak256(bytes(description))
+        );
+
+        // support & check status
+        vm.prank(bob);
+        paramMgr.castVote(
+            proposalId,
+            uint8(GovernorCountingSimple.VoteType.For)
+        );
+        vm.roll(block.number + _VOTING_PERIOD + 1);
+        vm.warp(block.timestamp + 13);
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Succeeded)
+        );
+
+        // queue
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 13);
+        paramMgr.queue(
+            targets,
+            values,
+            calldatas,
+            keccak256(bytes(description))
+        );
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Queued)
+        );
+
+        // execute
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + _TIMELOCK_MIN_DELAY + 13);
+        paramMgr.execute(
+            targets,
+            values,
+            calldatas,
+            keccak256(bytes(description))
+        );
+        assertEq(
+            uint8(paramMgr.state(proposalId)),
+            uint8(IGovernor.ProposalState.Executed)
+        );
+
+        // check execution
+        assertEq(term.getParameters().maxDebtPerCollateralToken, maxDebtPerCollateralToken);
+    }
+}

--- a/test/unit/governance/RewardSweeper.t.sol
+++ b/test/unit/governance/RewardSweeper.t.sol
@@ -183,4 +183,14 @@ contract RewardSweeperUnitTest is ECGTest {
         assertEq(reward.balanceOf(msig), rewardAmount);
         assertEq(reward.balanceOf(address(term)), 0);
     }
+
+    function testDeactivate() public {
+        vm.expectRevert("RewardSweeper: invalid sender");
+        sweeper.deactivate(); // nok, no prank
+
+        vm.prank(sweeper.receiver());
+        sweeper.deactivate();
+
+        assertEq(core.hasRole(CoreRoles.GOVERNOR, address(sweeper)), false);
+    }
 }

--- a/test/unit/loan/LendingTermAdjustable.t.sol
+++ b/test/unit/loan/LendingTermAdjustable.t.sol
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.13;
+
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
+import {ECGTest} from "@test/ECGTest.sol";
+import {Core} from "@src/core/Core.sol";
+import {CoreRoles} from "@src/core/CoreRoles.sol";
+import {MockERC20} from "@test/mock/MockERC20.sol";
+import {SimplePSM} from "@src/loan/SimplePSM.sol";
+import {GuildToken} from "@src/tokens/GuildToken.sol";
+import {CreditToken} from "@src/tokens/CreditToken.sol";
+import {LendingTerm} from "@src/loan/LendingTerm.sol";
+import {AuctionHouse} from "@src/loan/AuctionHouse.sol";
+import {ProfitManager} from "@src/governance/ProfitManager.sol";
+import {RateLimitedMinter} from "@src/rate-limits/RateLimitedMinter.sol";
+import {LendingTermAdjustable} from "@src/loan/LendingTermAdjustable.sol";
+
+contract LendingTermAdjustableUnitTest is ECGTest {
+    address private governor = address(1);
+    address private guardian = address(2);
+    Core private core;
+    ProfitManager public profitManager;
+    CreditToken credit;
+    GuildToken guild;
+    MockERC20 collateral;
+    SimplePSM private psm;
+    RateLimitedMinter rlcm;
+    AuctionHouse auctionHouse;
+    LendingTermAdjustable term;
+
+    // LendingTerm params
+    uint256 constant _CREDIT_PER_COLLATERAL_TOKEN = 2000e18; // 2000, same decimals
+    uint256 constant _INTEREST_RATE = 0.10e18; // 10% APR
+    uint256 constant _MAX_DELAY_BETWEEN_PARTIAL_REPAY = 31557600; // 1 years
+    uint256 constant _MIN_PARTIAL_REPAY_PERCENT = 0.2e18; // 20%
+    uint256 constant _HARDCAP = 20_000_000e18;
+
+    uint256 public issuance = 0;
+
+    function setUp() public {
+        vm.warp(1679067867);
+        vm.roll(16848497);
+        core = new Core();
+
+        profitManager = new ProfitManager(address(core));
+        collateral = new MockERC20();
+        credit = new CreditToken(address(core), "name", "symbol");
+        guild = new GuildToken(address(core));
+        rlcm = new RateLimitedMinter(
+            address(core) /*_core*/,
+            address(credit) /*_token*/,
+            CoreRoles.RATE_LIMITED_CREDIT_MINTER /*_role*/,
+            type(uint256).max /*_maxRateLimitPerSecond*/,
+            type(uint128).max /*_rateLimitPerSecond*/,
+            type(uint128).max /*_bufferCap*/
+        );
+        auctionHouse = new AuctionHouse(address(core), 650, 1800, 0);
+        term = LendingTermAdjustable(Clones.clone(address(new LendingTermAdjustable())));
+        term.initialize(
+            address(core),
+            LendingTerm.LendingTermReferences({
+                profitManager: address(profitManager),
+                guildToken: address(guild),
+                auctionHouse: address(auctionHouse),
+                creditMinter: address(rlcm),
+                creditToken: address(credit)
+            }),
+            abi.encode(
+                LendingTerm.LendingTermParams({
+                    collateralToken: address(collateral),
+                    maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
+                    interestRate: _INTEREST_RATE,
+                    maxDelayBetweenPartialRepay: _MAX_DELAY_BETWEEN_PARTIAL_REPAY,
+                    minPartialRepayPercent: _MIN_PARTIAL_REPAY_PERCENT,
+                    openingFee: 0,
+                    hardCap: _HARDCAP
+                })
+            )
+        );
+        psm = new SimplePSM(
+            address(core),
+            address(profitManager),
+            address(credit),
+            address(collateral)
+        );
+        profitManager.initializeReferences(address(credit), address(guild));
+
+        // roles
+        core.grantRole(CoreRoles.GOVERNOR, governor);
+        core.grantRole(CoreRoles.GUARDIAN, guardian);
+        core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
+        core.grantRole(CoreRoles.GUILD_MINTER, address(this));
+        core.grantRole(CoreRoles.GAUGE_ADD, address(this));
+        core.grantRole(CoreRoles.GAUGE_REMOVE, address(this));
+        core.grantRole(CoreRoles.GAUGE_PARAMETERS, address(this));
+        core.grantRole(CoreRoles.CREDIT_MINTER, address(rlcm));
+        core.grantRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, address(term));
+        core.grantRole(CoreRoles.GAUGE_PNL_NOTIFIER, address(term));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(term));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(profitManager));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(psm));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(this));
+        core.renounceRole(CoreRoles.GOVERNOR, address(this));
+
+        // add gauge and vote for it
+        guild.setMaxGauges(10);
+        guild.addGauge(1, address(term));
+        guild.mint(address(this), _HARDCAP * 2);
+        guild.incrementGauge(address(term), _HARDCAP);
+
+        // labels
+        vm.label(address(core), "core");
+        vm.label(address(profitManager), "profitManager");
+        vm.label(address(collateral), "collateral");
+        vm.label(address(credit), "credit");
+        vm.label(address(guild), "guild");
+        vm.label(address(rlcm), "rlcm");
+        vm.label(address(auctionHouse), "auctionHouse");
+        vm.label(address(term), "term");
+        vm.label(address(this), "test");
+    }
+
+    // test setter for interestRate
+    function testSetInterestRate() public {
+        assertEq(term.getParameters().interestRate, _INTEREST_RATE);
+
+        vm.prank(governor);
+        term.setInterestRate(_INTEREST_RATE * 2);
+
+        assertEq(term.getParameters().interestRate, _INTEREST_RATE * 2);
+
+        vm.expectRevert("UNAUTHORIZED");
+        term.setInterestRate(_INTEREST_RATE);
+    }
+
+    // test setter for maxDebtPerCollateralToken
+    function testSetMaxDebtPerCollateralToken() public {
+        assertEq(term.getParameters().maxDebtPerCollateralToken, _CREDIT_PER_COLLATERAL_TOKEN);
+
+        vm.prank(governor);
+        term.setMaxDebtPerCollateralToken(_CREDIT_PER_COLLATERAL_TOKEN * 2);
+
+        assertEq(term.getParameters().maxDebtPerCollateralToken, _CREDIT_PER_COLLATERAL_TOKEN * 2);
+
+        vm.expectRevert("UNAUTHORIZED");
+        term.setMaxDebtPerCollateralToken(_CREDIT_PER_COLLATERAL_TOKEN);
+    }
+
+    // get loan debt when interest rate changes over time
+    function testGetLoanDebt() public {
+        // prepare
+        uint256 period = term.YEAR();
+        collateral.mint(address(this), 1 ether * 2);
+        collateral.approve(address(term), 1 ether * 2);
+
+        // borrow
+        bytes32 loan1 = term.borrow(1_000 ether, 1 ether);
+        assertEq(term.getLoanDebt(loan1), 1_000 ether);
+
+        // 10% apr * full period -> x1.10
+        vm.warp(block.timestamp + period);
+        assertEq(term.getLoanDebt(loan1), 1_100 ether);
+
+        // set interest rate to 100% APR
+        vm.prank(governor);
+        term.setInterestRate(1e18);
+
+        // 100% APR * full period -> x2.00
+        vm.warp(block.timestamp + period);
+        assertEq(term.getLoanDebt(loan1), 2_200 ether);
+
+        // set interest rate to 50% APR
+        vm.prank(governor);
+        term.setInterestRate(0.5e18);
+
+        // 50% APR * half a period -> x1.25
+        vm.warp(block.timestamp + period / 2);
+        assertEq(term.getLoanDebt(loan1), 2_750 ether);
+
+        // borrow 2
+        bytes32 loan2 = term.borrow(1_000 ether, 1 ether);
+        assertEq(term.getLoanDebt(loan2), 1_000 ether);
+
+        // 50% APR * half a period -> x1.25
+        vm.warp(block.timestamp + period / 2);
+        assertEq(term.getLoanDebt(loan1), 3_437.5 ether);
+        assertEq(term.getLoanDebt(loan2), 1_250 ether);
+    }
+
+    // setting maxDebtPerCollateralToken can make loans callable
+    function testLoansBecomeCallable() public {
+        // prepare
+        uint256 period = term.YEAR();
+        collateral.mint(address(this), 1 ether * 2);
+        collateral.approve(address(term), 1 ether * 2);
+
+        // borrow
+        bytes32 loan1 = term.borrow(1_000 ether, 1 ether);
+        vm.expectRevert("LendingTerm: cannot call");
+        term.call(loan1);
+
+        // after some time, set maxDebtPerCollateralToken to 1000
+        vm.warp(block.timestamp + 123456);
+        vm.prank(governor);
+        term.setMaxDebtPerCollateralToken(1000 ether);
+
+        // now loan can be called
+        term.call(loan1);
+        assertEq(term.getLoan(loan1).callTime, block.timestamp);
+    }
+}

--- a/test/unit/loan/LendingTermAdjustable.t.sol
+++ b/test/unit/loan/LendingTermAdjustable.t.sol
@@ -191,7 +191,6 @@ contract LendingTermAdjustableUnitTest is ECGTest {
     // setting maxDebtPerCollateralToken can make loans callable
     function testLoansBecomeCallable() public {
         // prepare
-        uint256 period = term.YEAR();
         collateral.mint(address(this), 1 ether * 2);
         collateral.approve(address(term), 1 ether * 2);
 

--- a/test/unit/loan/RewardSweeper.t.sol
+++ b/test/unit/loan/RewardSweeper.t.sol
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.13;
+
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
+import {ECGTest} from "@test/ECGTest.sol";
+import {Core} from "@src/core/Core.sol";
+import {CoreRoles} from "@src/core/CoreRoles.sol";
+import {MockERC20} from "@test/mock/MockERC20.sol";
+import {SimplePSM} from "@src/loan/SimplePSM.sol";
+import {GuildToken} from "@src/tokens/GuildToken.sol";
+import {CreditToken} from "@src/tokens/CreditToken.sol";
+import {LendingTerm} from "@src/loan/LendingTerm.sol";
+import {AuctionHouse} from "@src/loan/AuctionHouse.sol";
+import {RewardSweeper} from "@src/governance/RewardSweeper.sol";
+import {ProfitManager} from "@src/governance/ProfitManager.sol";
+import {RateLimitedMinter} from "@src/rate-limits/RateLimitedMinter.sol";
+
+contract RewardSweeperUnitTest is ECGTest {
+    address private governor = address(1);
+    address private guardian = address(2);
+    address private msig = address(789546);
+    Core private core;
+    ProfitManager public profitManager;
+    CreditToken credit;
+    GuildToken guild;
+    MockERC20 collateral;
+    MockERC20 reward;
+    SimplePSM private psm;
+    RateLimitedMinter rlcm;
+    AuctionHouse auctionHouse;
+    LendingTerm term;
+    RewardSweeper sweeper;
+
+    // LendingTerm params
+    uint256 constant _CREDIT_PER_COLLATERAL_TOKEN = 2000e18; // 2000, same decimals
+    uint256 constant _INTEREST_RATE = 0.10e18; // 10% APR
+    uint256 constant _MAX_DELAY_BETWEEN_PARTIAL_REPAY = 31557600; // 1 years
+    uint256 constant _MIN_PARTIAL_REPAY_PERCENT = 0.2e18; // 20%
+    uint256 constant _HARDCAP = 20_000_000e18;
+
+    uint256 public issuance = 0;
+
+    function setUp() public {
+        vm.warp(1679067867);
+        vm.roll(16848497);
+        core = new Core();
+
+        profitManager = new ProfitManager(address(core));
+        collateral = new MockERC20();
+        reward = new MockERC20();
+        credit = new CreditToken(address(core), "name", "symbol");
+        guild = new GuildToken(address(core));
+        rlcm = new RateLimitedMinter(
+            address(core) /*_core*/,
+            address(credit) /*_token*/,
+            CoreRoles.RATE_LIMITED_CREDIT_MINTER /*_role*/,
+            type(uint256).max /*_maxRateLimitPerSecond*/,
+            type(uint128).max /*_rateLimitPerSecond*/,
+            type(uint128).max /*_bufferCap*/
+        );
+        auctionHouse = new AuctionHouse(address(core), 650, 1800, 0);
+        term = LendingTerm(Clones.clone(address(new LendingTerm())));
+        term.initialize(
+            address(core),
+            LendingTerm.LendingTermReferences({
+                profitManager: address(profitManager),
+                guildToken: address(guild),
+                auctionHouse: address(auctionHouse),
+                creditMinter: address(rlcm),
+                creditToken: address(credit)
+            }),
+            abi.encode(
+                LendingTerm.LendingTermParams({
+                    collateralToken: address(collateral),
+                    maxDebtPerCollateralToken: _CREDIT_PER_COLLATERAL_TOKEN,
+                    interestRate: _INTEREST_RATE,
+                    maxDelayBetweenPartialRepay: _MAX_DELAY_BETWEEN_PARTIAL_REPAY,
+                    minPartialRepayPercent: _MIN_PARTIAL_REPAY_PERCENT,
+                    openingFee: 0,
+                    hardCap: _HARDCAP
+                })
+            )
+        );
+        psm = new SimplePSM(
+            address(core),
+            address(profitManager),
+            address(credit),
+            address(collateral)
+        );
+        profitManager.initializeReferences(address(credit), address(guild));
+
+        sweeper = new RewardSweeper(address(core), address(guild), msig);
+
+        // roles
+        core.grantRole(CoreRoles.GOVERNOR, governor);
+        core.grantRole(CoreRoles.GUARDIAN, guardian);
+        core.grantRole(CoreRoles.CREDIT_MINTER, address(this));
+        core.grantRole(CoreRoles.GUILD_MINTER, address(this));
+        core.grantRole(CoreRoles.GAUGE_ADD, address(this));
+        core.grantRole(CoreRoles.GAUGE_REMOVE, address(this));
+        core.grantRole(CoreRoles.GAUGE_PARAMETERS, address(this));
+        core.grantRole(CoreRoles.CREDIT_MINTER, address(rlcm));
+        core.grantRole(CoreRoles.RATE_LIMITED_CREDIT_MINTER, address(term));
+        core.grantRole(CoreRoles.GAUGE_PNL_NOTIFIER, address(term));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(term));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(profitManager));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(psm));
+        core.grantRole(CoreRoles.CREDIT_BURNER, address(this));
+        core.grantRole(CoreRoles.GOVERNOR, address(sweeper));
+        core.renounceRole(CoreRoles.GOVERNOR, address(this));
+
+        // add gauge and vote for it
+        guild.setMaxGauges(10);
+        guild.addGauge(1, address(term));
+        guild.mint(address(this), _HARDCAP * 2);
+        guild.incrementGauge(address(term), _HARDCAP);
+
+        // labels
+        vm.label(address(core), "core");
+        vm.label(address(profitManager), "profitManager");
+        vm.label(address(collateral), "collateral");
+        vm.label(address(credit), "credit");
+        vm.label(address(guild), "guild");
+        vm.label(address(rlcm), "rlcm");
+        vm.label(address(auctionHouse), "auctionHouse");
+        vm.label(address(term), "term");
+        vm.label(address(sweeper), "sweeper");
+        vm.label(address(this), "test");
+    }
+
+    function testInitialState() public {
+        assertEq(address(sweeper.core()), address(core));
+        assertEq(sweeper.receiver(), msig);
+    }
+
+    function testSetReceiver() public {
+        assertEq(sweeper.receiver(), msig);
+
+        vm.prank(governor);
+        sweeper.setReceiver(address(123456));
+
+        assertEq(sweeper.receiver(), address(123456));
+
+        vm.expectRevert("UNAUTHORIZED");
+        sweeper.setReceiver(msig);
+    }
+
+    function testOnlyReceiverCanSweep() public {
+        vm.prank(sweeper.receiver());
+        sweeper.sweep(address(term), address(reward)); // ok
+
+        vm.expectRevert("RewardSweeper: invalid sender");
+        sweeper.sweep(address(term), address(reward)); // nok, no prank
+    }
+
+    function testCanOnlySweepGauges() public {
+        vm.startPrank(sweeper.receiver());
+        sweeper.sweep(address(term), address(reward)); // ok
+
+        vm.expectRevert("RewardSweeper: invalid gauge");
+        sweeper.sweep(address(456789), address(reward)); // nok, not a live term
+    }
+
+    function testCannotSweepCollateralToken() public {
+        vm.startPrank(sweeper.receiver());
+        sweeper.sweep(address(term), address(reward)); // ok
+
+        vm.expectRevert("RewardSweeper: invalid token");
+        sweeper.sweep(address(term), address(collateral)); // nok, invalid token
+    }
+
+    function testSweep() public {
+        uint256 rewardAmount = 123456;
+        reward.mint(address(term), rewardAmount);
+
+        assertEq(reward.balanceOf(msig), 0);
+        assertEq(reward.balanceOf(address(term)), rewardAmount);
+
+        vm.prank(msig);
+        sweeper.sweep(address(term), address(reward));
+
+        assertEq(reward.balanceOf(msig), rewardAmount);
+        assertEq(reward.balanceOf(address(term)), 0);
+    }
+}


### PR DESCRIPTION
Adjustable lending term implementation + governance process to update `interestRate`, `maxDebtPerCollateralToken`, and `hardCap` on live terms, without requiring a migration from borrowers.

- [x] Checkpointing logic in `LendingTerm` for changing interest rates
- [x] Add setters for `interestRate` & `maxDebtPerCollateralToken`
- [x] Add governance process for parameter updates

Enable reward tokens sweeping to a safe address (Team multisig) for distribution to borrowers / lenders as appropriate. There is currently no way to recover reward tokens airdropped to `LendingTerm`s without having to go through the main DAO timelock every time. The addition of the `RewardSweeper` helper contract will allow to pull reward tokens to the multisig to handle distributions.
- [x] Add `RewardSweeper` helper contract

General
- [x] Add proposal script to enact new features through the DAO timelock
